### PR TITLE
feat(portal): add createPortal for rendering outside the component tree

### DIFF
--- a/demo/app.ts
+++ b/demo/app.ts
@@ -4,6 +4,7 @@ import { TEXTS, TAGS, COLORS } from './data.js'
 import { computeColumns, getTagWidth, distributeToColumns } from './layout.js'
 import { TagBubble, Card, HeroCard } from './components.js'
 import { initControls } from './controls.js'
+import { initPortalDemo } from './portal-demo.js'
 
 // ============================================================
 // Signals
@@ -106,3 +107,9 @@ function syncContainerWidth(w: number) {
 // ============================================================
 
 initControls({ containerWidth, itemCount, app, appEl })
+
+// ============================================================
+// Portal Demo — initialized after main app is mounted
+// ============================================================
+
+initPortalDemo()

--- a/demo/portal-demo.ts
+++ b/demo/portal-demo.ts
@@ -1,0 +1,165 @@
+import { signal, defineComponent, createPortal, createApp } from '../src/index.js'
+
+// ============================================================
+// Portal Demo — standalone section demonstrating createPortal
+//
+// Renders its own Axiom app into a dedicated container that is
+// appended to #app, so it stays visually inside the page but
+// is fully independent of the main Axiom instance.
+//
+// The modal is rendered via createPortal into document.body,
+// completely outside the app root — that's the whole point.
+// ============================================================
+
+const isModalOpen = signal(false)
+
+// ============================================================
+// Modal content component — rendered into document.body
+// ============================================================
+
+const ModalPortal = defineComponent(() => {
+  if (!isModalOpen.value) {
+    return { type: 'fragment' as const, children: [] }
+  }
+
+  return createPortal(
+    [
+      {
+        type: 'element' as const,
+        tag: 'div',
+        classes: ['portal-overlay'],
+        on: {
+          click: (e: Event) => {
+            if ((e.target as HTMLElement).classList.contains('portal-overlay')) {
+              isModalOpen.value = false
+            }
+          },
+        },
+        children: [
+          {
+            type: 'element' as const,
+            tag: 'div',
+            classes: ['portal-modal'],
+            children: [
+              {
+                type: 'element' as const,
+                tag: 'div',
+                classes: ['portal-modal-header'],
+                children: [
+                  {
+                    type: 'element' as const,
+                    tag: 'h2',
+                    classes: ['portal-modal-title'],
+                    children: [{ type: 'text' as const, content: '✨ Portal Modal' }],
+                  },
+                  {
+                    type: 'element' as const,
+                    tag: 'button',
+                    classes: ['portal-close-btn'],
+                    on: {
+                      click: () => {
+                        isModalOpen.value = false
+                      },
+                    },
+                    children: [{ type: 'text' as const, content: '✕' }],
+                  },
+                ],
+              },
+              {
+                type: 'element' as const,
+                tag: 'p',
+                classes: ['portal-modal-body'],
+                children: [
+                  {
+                    type: 'text' as const,
+                    content:
+                      'This modal is rendered via createPortal into document.body — completely outside the #app root. The component tree stays clean; the DOM target is arbitrary.',
+                  },
+                ],
+              },
+              {
+                type: 'element' as const,
+                tag: 'p',
+                classes: ['portal-modal-body'],
+                children: [
+                  {
+                    type: 'text' as const,
+                    content:
+                      'Reactivity works normally: a signal controls visibility, and Axiom diffs only what changed — even across DOM boundaries.',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    document.body
+  )
+})
+
+// ============================================================
+// Trigger + portal root component — the full demo section
+// ============================================================
+
+const PortalDemo = defineComponent(() => ({
+  type: 'element' as const,
+  tag: 'div',
+  classes: ['card', 'portal-demo-section'],
+  layout: { flexDirection: 'column' as const, gap: 10, padding: 16 },
+  children: [
+    {
+      type: 'element' as const,
+      tag: 'div',
+      classes: ['hero-badge'],
+      children: [{ type: 'text' as const, content: '🌀 PORTAL DEMO' }],
+    },
+    {
+      type: 'element' as const,
+      tag: 'h2',
+      classes: ['hero-title'],
+      children: [{ type: 'text' as const, content: 'createPortal' }],
+    },
+    {
+      type: 'element' as const,
+      tag: 'p',
+      classes: ['hero-body'],
+      children: [
+        {
+          type: 'text' as const,
+          content:
+            'Renders children into an arbitrary DOM node outside the component tree. Perfect for modals, tooltips, and overlays that need to escape overflow/stacking contexts.',
+        },
+      ],
+    },
+    {
+      type: 'element' as const,
+      tag: 'button',
+      classes: ['portal-trigger-btn'],
+      on: {
+        click: () => {
+          isModalOpen.value = true
+        },
+      },
+      children: [{ type: 'text' as const, content: '🚀 Open Portal Modal' }],
+    },
+    // ModalPortal lives here in the logical tree but renders into document.body
+    ModalPortal(),
+  ],
+}))
+
+// ============================================================
+// Mount the portal demo section
+// ============================================================
+
+export function initPortalDemo() {
+  const container = document.createElement('div')
+  container.id = 'portal-demo-root'
+
+  // Insert after #app so it appears below the main demo
+  const appEl = document.getElementById('app')!
+  appEl.after(container)
+
+  const portalApp = createApp(PortalDemo, container, { lineHeight: 20 })
+  portalApp.mount()
+}

--- a/demo/portal-demo.ts
+++ b/demo/portal-demo.ts
@@ -7,14 +7,34 @@ import { signal, defineComponent, createPortal, createApp } from '../src/index.j
 // appended to #app, so it stays visually inside the page but
 // is fully independent of the main Axiom instance.
 //
-// The modal is rendered via createPortal into document.body,
-// completely outside the app root — that's the whole point.
+// The modal is rendered via createPortal into a DEDICATED
+// #portal-modal-root container — NOT directly into document.body.
+// Best practice: always target a controlled container, not body.
+// This ensures Axiom only removes what it inserted on cleanup.
 // ============================================================
 
 const isModalOpen = signal(false)
 
 // ============================================================
-// Modal content component — rendered into document.body
+// Modal root — dedicated container for portal output
+//
+// Best practice: never use document.body directly as a portal
+// target. Instead, create a dedicated container so Axiom only
+// manages content it inserted, without risking other DOM nodes.
+// ============================================================
+
+function getOrCreateModalRoot(): HTMLElement {
+  let el = document.getElementById('portal-modal-root')
+  if (el === null) {
+    el = document.createElement('div')
+    el.id = 'portal-modal-root'
+    document.body.appendChild(el)
+  }
+  return el
+}
+
+// ============================================================
+// Modal content component — rendered into #portal-modal-root
 // ============================================================
 
 const ModalPortal = defineComponent(() => {
@@ -73,7 +93,7 @@ const ModalPortal = defineComponent(() => {
                   {
                     type: 'text' as const,
                     content:
-                      'This modal is rendered via createPortal into document.body — completely outside the #app root. The component tree stays clean; the DOM target is arbitrary.',
+                      'This modal is rendered via createPortal into #portal-modal-root — a dedicated container outside the #app root. The component tree stays clean; the DOM target is arbitrary.',
                   },
                 ],
               },
@@ -94,7 +114,7 @@ const ModalPortal = defineComponent(() => {
         ],
       },
     ],
-    document.body
+    getOrCreateModalRoot()
   )
 })
 
@@ -153,6 +173,11 @@ const PortalDemo = defineComponent(() => ({
 // ============================================================
 
 export function initPortalDemo() {
+  // Create the dedicated portal modal root — Axiom renders modal content here.
+  // Using a dedicated container (not document.body) is the recommended pattern:
+  // it ensures Axiom only removes what it inserted on cleanup.
+  getOrCreateModalRoot()
+
   const container = document.createElement('div')
   container.id = 'portal-demo-root'
 

--- a/demo/style.css
+++ b/demo/style.css
@@ -272,3 +272,110 @@ body {
   color: var(--accent-teal);
   white-space: nowrap;
 }
+
+/* ============================================================
+   Portal Demo — Trigger section & Modal overlay
+   ============================================================ */
+
+.portal-demo-section {
+  background: linear-gradient(135deg, rgba(13, 148, 136, 0.1), rgba(124, 58, 237, 0.1));
+  border-color: rgba(13, 148, 136, 0.4);
+  box-shadow: 0 8px 32px rgba(13, 148, 136, 0.1);
+}
+
+.portal-trigger-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 20px;
+  border-radius: 8px;
+  border: 1px solid var(--accent-teal);
+  background: rgba(13, 148, 136, 0.15);
+  color: var(--accent-teal);
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  transition: all 0.15s;
+  width: fit-content;
+}
+
+.portal-trigger-btn:hover {
+  background: rgba(13, 148, 136, 0.3);
+  box-shadow: 0 0 16px rgba(13, 148, 136, 0.25);
+}
+
+/* Modal overlay — rendered by portal into document.body */
+
+.portal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  backdrop-filter: blur(4px);
+  animation: portal-fade-in 0.15s ease;
+}
+
+@keyframes portal-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.portal-modal {
+  background: var(--surface-2);
+  border: 1px solid rgba(124, 58, 237, 0.5);
+  border-radius: 16px;
+  padding: 28px 32px;
+  max-width: 500px;
+  width: 90%;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(124, 58, 237, 0.15);
+  animation: portal-slide-up 0.2s ease;
+}
+
+@keyframes portal-slide-up {
+  from { transform: translateY(12px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.portal-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.portal-modal-title {
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.portal-close-btn {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  transition: all 0.15s;
+}
+
+.portal-close-btn:hover {
+  border-color: var(--accent-rose);
+  color: var(--accent-rose);
+  background: rgba(225, 29, 72, 0.1);
+}
+
+.portal-modal-body {
+  color: var(--text-muted);
+  font-size: 14px;
+  line-height: 1.6;
+  margin-top: 12px;
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -51,7 +51,7 @@ export function createApp(
   const state: AppState = {
     prevPrepared: null,
     prevLayout: null,
-    domState: { domNodes: [] },
+    domState: { domNodes: [], portalRoots: new Map() },
     mounted: false,
     stopEffect: null,
     metrics: { prepareMs: 0, reflowMs: 0, commitMs: 0 },
@@ -119,8 +119,13 @@ export function createApp(
       // Shape change (e.g. column count changed) — full teardown and re-commit.
       // applyOps can't handle hierarchy changes because it flat-appends inserts to root.
       fireUnmountEvents(state.domState.domNodes)
+      // Clear portal targets BEFORE resetting root — they are outside root.innerHTML scope
+      for (const portalTarget of state.domState.portalRoots.values()) {
+        portalTarget.innerHTML = ''
+      }
       root.innerHTML = ''
       state.domState.domNodes = []
+      state.domState.portalRoots = new Map()
       commitFull(layout, prepared, root, state.domState)
     } else {
       // Value change only — incremental diff and apply
@@ -175,6 +180,10 @@ export function createApp(
       state.stopEffect?.()
       cancelScheduled()
       fireUnmountEvents(state.domState.domNodes)
+      // Clear portal targets BEFORE wiping root — they live outside root DOM scope
+      for (const portalTarget of state.domState.portalRoots.values()) {
+        portalTarget.innerHTML = ''
+      }
       root.innerHTML = ''
       state.mounted = false
       state.prevPrepared = null
@@ -182,6 +191,7 @@ export function createApp(
       // Replace the array reference (not just fill) to release all DOM node references
       // and allow the GC to collect them, preventing memory leaks in long-lived apps.
       state.domState.domNodes = []
+      state.domState.portalRoots = new Map()
     },
 
     getMetrics(): RenderMetrics {

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,12 +4,27 @@ import type { SchedulerFn } from './scheduler.js'
 import type { ReflowOptions } from './reflow.js'
 
 import { prepare, resetIndexCounter } from './prepare.js'
-import { reflow, createLayoutResult } from './reflow.js'
+import { reflow } from './reflow.js'
 import { fullDiff, type DOMOperation } from './diff.js'
 import { commitFull, applyOps, fireUnmountEvents, type DOMState } from './commit.js'
 import { effect } from './signals.js'
 import { scheduleRender, cancelScheduled } from './scheduler.js'
 import { getNodeType, getTag, getChildren } from './prepare.js'
+
+// ============================================================
+// Internal helpers
+// ============================================================
+
+/** Remove only the DOM nodes Axiom inserted into each portal target — never nuke foreign content. */
+function clearPortalRoots(domState: DOMState): void {
+  for (const entry of domState.portalRoots.values()) {
+    for (const node of entry.nodes) {
+      if (node.parentNode === entry.target) {
+        entry.target.removeChild(node)
+      }
+    }
+  }
+}
 
 // ============================================================
 // Public API
@@ -120,9 +135,7 @@ export function createApp(
       // applyOps can't handle hierarchy changes because it flat-appends inserts to root.
       fireUnmountEvents(state.domState.domNodes)
       // Clear portal targets BEFORE resetting root — they are outside root.innerHTML scope
-      for (const portalTarget of state.domState.portalRoots.values()) {
-        portalTarget.innerHTML = ''
-      }
+      clearPortalRoots(state.domState)
       root.innerHTML = ''
       state.domState.domNodes = []
       state.domState.portalRoots = new Map()
@@ -181,9 +194,7 @@ export function createApp(
       cancelScheduled()
       fireUnmountEvents(state.domState.domNodes)
       // Clear portal targets BEFORE wiping root — they live outside root DOM scope
-      for (const portalTarget of state.domState.portalRoots.values()) {
-        portalTarget.innerHTML = ''
-      }
+      clearPortalRoots(state.domState)
       root.innerHTML = ''
       state.mounted = false
       state.prevPrepared = null

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -26,9 +26,14 @@ import {
 // Public API
 // ============================================================
 
+export interface PortalEntry {
+  target: HTMLElement
+  nodes: Node[]
+}
+
 export interface DOMState {
   domNodes: Array<HTMLElement | Text | null>
-  portalRoots: Map<number, HTMLElement>  // _index → targetElement
+  portalRoots: Map<number, PortalEntry>  // _index → { target, nodes[] }
 }
 
 export function commitFull(
@@ -221,9 +226,16 @@ function buildDOMTree(
     // Portal: redirect children to the portalTarget, not the current parent
     const portalTarget = getPortalTarget(prepared)
     if (portalTarget !== undefined) {
-      state.portalRoots.set(idx, portalTarget)
+      const entry: PortalEntry = { target: portalTarget, nodes: [] }
+      state.portalRoots.set(idx, entry)
       for (const child of children) {
+        // Capture childNodes count before insertion to track root-level nodes added
+        const before = portalTarget.childNodes.length
         buildDOMTree(child, layout, portalTarget, state)
+        // Collect any new direct children of portalTarget added by this child
+        for (let i = before; i < portalTarget.childNodes.length; i++) {
+          entry.nodes.push(portalTarget.childNodes[i]!)
+        }
       }
     }
     return

--- a/src/commit.ts
+++ b/src/commit.ts
@@ -19,6 +19,7 @@ import {
   getOn,
   forEachNode,
   getPreparedChildren,
+  getPortalTarget,
 } from './prepare.js'
 
 // ============================================================
@@ -27,6 +28,7 @@ import {
 
 export interface DOMState {
   domNodes: Array<HTMLElement | Text | null>
+  portalRoots: Map<number, HTMLElement>  // _index → targetElement
 }
 
 export function commitFull(
@@ -148,18 +150,27 @@ export function applyOps(
     }
   }
 
-  // Phase 3: Inserts — use DocumentFragment for batching
-  const fragment = document.createDocumentFragment()
+  // Phase 3: Inserts — use per-container DocumentFragment for batching
+  // This supports portal inserts which target a different container than root.
+  const fragments = new Map<HTMLElement, DocumentFragment>()
   for (const op of ops) {
     if (op.type === 'insert') {
       const el = createDOMElement(op)
       domNodes[op.index] = el
-      fragment.appendChild(el)
+      const container = op.portalTarget ?? root
+      let frag = fragments.get(container)
+      if (frag === undefined) {
+        frag = document.createDocumentFragment()
+        fragments.set(container, frag)
+      }
+      frag.appendChild(el)
     }
   }
 
-  if (fragment.childNodes.length > 0) {
-    root.appendChild(fragment)
+  for (const [container, frag] of fragments) {
+    if (frag.childNodes.length > 0) {
+      container.appendChild(frag)
+    }
   }
 
   // Phase 4: Trigger mount events after DOM insertion
@@ -202,6 +213,18 @@ function buildDOMTree(
     // Fragments are transparent — just process children
     for (const child of children) {
       buildDOMTree(child, layout, parent, state)
+    }
+    return
+  }
+
+  if (nodeType === 'portal') {
+    // Portal: redirect children to the portalTarget, not the current parent
+    const portalTarget = getPortalTarget(prepared)
+    if (portalTarget !== undefined) {
+      state.portalRoots.set(idx, portalTarget)
+      for (const child of children) {
+        buildDOMTree(child, layout, portalTarget, state)
+      }
     }
     return
   }

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -32,6 +32,8 @@ export interface DOMOperation {
   attrs?: Record<string, string>
   on?: Record<string, EventListener>
   key?: string
+  /** When set, this insert targets a portal container instead of the app root */
+  portalTarget?: HTMLElement
   // For update/move
   x?: number
   y?: number

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -15,6 +15,7 @@ import {
   forEachNode,
   countNodes,
   getPreparedChildren,
+  getPortalTarget,
 } from './prepare.js'
 
 // ============================================================
@@ -41,6 +42,33 @@ export interface DOMOperation {
   height?: number
   newTextContent?: string
   newOn?: Record<string, EventListener>
+}
+
+// ============================================================
+// Portal Map — maps every descendant node index to its portalTarget
+// ============================================================
+
+function buildPortalMap(prepared: PreparedComponent): Map<number, HTMLElement> {
+  const map = new Map<number, HTMLElement>()
+  function walk(node: PreparedComponent, currentPortalTarget?: HTMLElement): void {
+    const nodeType = getNodeType(node)
+    const idx = getNodeIndex(node)
+    if (nodeType === 'portal') {
+      const target = getPortalTarget(node)
+      for (const child of getPreparedChildren(node)) {
+        walk(child, target)
+      }
+    } else {
+      if (currentPortalTarget !== undefined) {
+        map.set(idx, currentPortalTarget)
+      }
+      for (const child of getPreparedChildren(node)) {
+        walk(child, currentPortalTarget)
+      }
+    }
+  }
+  walk(prepared)
+  return map
 }
 
 // ============================================================
@@ -78,6 +106,7 @@ export function fullDiff(
 
   // First render — all inserts
   if (prevPrepared === null) {
+    const portalMap = buildPortalMap(newPrepared)
     forEachNode(newPrepared, (node) => {
       const idx = getNodeIndex(node)
       const op: DOMOperation = { type: 'insert', index: idx }
@@ -91,6 +120,11 @@ export function fullDiff(
         op.key = getKey(node)
       } else if (nodeType === 'text') {
         op.textContent = getTextContent(node)
+      }
+
+      const portalTarget = portalMap.get(idx)
+      if (portalTarget !== undefined) {
+        op.portalTarget = portalTarget
       }
 
       ops.push(op)
@@ -168,6 +202,9 @@ function fullTreeDiff(
 ): DOMOperation[] {
   const ops: DOMOperation[] = []
 
+  // Build portal map to propagate portalTarget to insert ops
+  const portalMap = buildPortalMap(newPrepared)
+
   // Build key maps for reconciliation
   const prevByKey = buildKeyMap(prevPrepared)
   const newByKey = buildKeyMap(newPrepared)
@@ -231,6 +268,10 @@ function fullTreeDiff(
         op.key = getKey(node)
       } else if (nodeType === 'text') {
         op.textContent = getTextContent(node)
+      }
+      const portalTarget = portalMap.get(idx)
+      if (portalTarget !== undefined) {
+        op.portalTarget = portalTarget
       }
       ops.push(op)
     } else {

--- a/src/fast-path.ts
+++ b/src/fast-path.ts
@@ -29,8 +29,18 @@ export function measureSimple(
   const gap = layout?.gap ?? 0
   let offsetY = 0
 
-  for (let i = 0; i < children.length; i++) {
-    const child = children[i]!
+  // Count non-portal children for gap calculation
+  const realChildren = children.filter(c => getNodeType(c) !== 'portal')
+  let realIdx = 0
+
+  for (const child of children) {
+    // Portals are invisible to parent layout — skip positioning,
+    // but still recurse to lay out their internal content
+    if (getNodeType(child) === 'portal') {
+      layoutChild(child, availableWidth, result, lineHeight)
+      continue
+    }
+
     const childIdx = getNodeIndex(child)
     const childWidth = availableWidth
 
@@ -43,13 +53,14 @@ export function measureSimple(
     layoutChild(child, childWidth, result, lineHeight)
 
     offsetY += result.height[childIdx]
-    if (i < children.length - 1) {
+    if (realIdx < realChildren.length - 1) {
       offsetY += gap
     }
+    realIdx++
   }
 
-  // Set parent height if not already set
-  if (result.height[parentIdx] === 0) {
+  // Set parent height if not already set (portals stay 0×0 — they don't occupy parent space)
+  if (result.height[parentIdx] === 0 && getNodeType(prepared) !== 'portal') {
     result.height[parentIdx] = offsetY
   }
 }

--- a/src/flex.ts
+++ b/src/flex.ts
@@ -83,6 +83,17 @@ export function measureFlex(
   let currentLine: FlexLine = { items: [], mainSize: 0, crossSize: 0 }
 
   for (const child of children) {
+    // Portals are invisible to flex layout — skip flex positioning,
+    // but still recurse to lay out their internal content
+    if (getNodeType(child) === 'portal') {
+      // Use simple layout for the portal's internal children
+      const childIdx = getNodeIndex(child)
+      result.width[childIdx] = 0
+      result.height[childIdx] = 0
+      measureSimple(child, availableWidth, result, lineHeight)
+      continue
+    }
+
     const childLayout = getLayoutProps(child)
     
     let childWidth = childLayout?.width

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,9 @@ export { signal, computed, effect } from './signals.js'
 // --- Components ---
 export { defineComponent } from './component.js'
 
+// --- Portals ---
+export { createPortal } from './portal.js'
+
 // --- App ---
 export { createApp } from './app.js'
 export type { App, AppOptions, RenderMetrics } from './app.js'
@@ -54,6 +57,7 @@ export type {
   ElementNode,
   TextNode,
   FragmentNode,
+  PortalNode,
   // Layout
   PreparedComponent,
   LayoutResult,

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -1,0 +1,17 @@
+import type { ComponentNode, PortalNode } from './types.js'
+
+// ============================================================
+// Portal factory — creates a PortalNode for rendering children
+// into an arbitrary DOM target outside the main component tree
+// ============================================================
+
+export function createPortal(
+  children: ComponentNode[],
+  target: HTMLElement
+): PortalNode {
+  return {
+    type: 'portal',
+    target,
+    children,
+  }
+}

--- a/src/portal.ts
+++ b/src/portal.ts
@@ -5,6 +5,47 @@ import type { ComponentNode, PortalNode } from './types.js'
 // into an arbitrary DOM target outside the main component tree
 // ============================================================
 
+/**
+ * Renders `children` into `target` — a DOM element outside the main app root —
+ * while keeping them part of the component tree for reactivity and lifecycle.
+ *
+ * ## CSS-managed behavior (current default)
+ *
+ * Portal children are **CSS-managed by default**: Axiom inserts them into the
+ * DOM but does NOT apply `position`, `transform`, `width`, or `height` inline
+ * styles. The user's CSS controls layout entirely.
+ *
+ * This is intentional for the common cases (modals, tooltips, drawers,
+ * notifications) where components rely on `position: fixed`, `display: flex`,
+ * or `backdrop-filter` — styles that Axiom's absolute positioning would override.
+ *
+ * ## Future: `cssManaged` flag (not yet implemented — see issue #9)
+ *
+ * For portals that render into a layout-controlled container (e.g., a carousel
+ * track, virtual list viewport, split-pane panel) and need Axiom's two-phase
+ * layout engine to calculate positions and sizes, a `cssManaged: false` option
+ * is planned:
+ *
+ * ```ts
+ * // Future API (not available yet):
+ * createPortal(children, target, { cssManaged: false })
+ * ```
+ *
+ * When `cssManaged: false`, Axiom would apply `position: absolute` and
+ * `transform: translate(x,y)` to portal children exactly like regular elements.
+ * Track progress at: https://github.com/naml14/axiom-framework/issues/9
+ *
+ * ## Recommended usage
+ *
+ * Use a **dedicated container element** as the target, not `document.body`
+ * directly. Axiom tracks and removes only the nodes it inserted, so shared
+ * containers are safe — but a dedicated container makes intent explicit:
+ *
+ * ```ts
+ * const modalRoot = document.getElementById('modal-root')!
+ * const modal = createPortal([...children], modalRoot)
+ * ```
+ */
 export function createPortal(
   children: ComponentNode[],
   target: HTMLElement

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -6,6 +6,7 @@ import type {
   TextNode,
   ElementNode,
   FragmentNode,
+  PortalNode,
 } from './types.js'
 
 // ============================================================
@@ -30,7 +31,7 @@ export interface PrepareOptions {
 interface PreparedInternal {
   _index: number
   key?: string
-  nodeType: 'element' | 'text' | 'fragment'
+  nodeType: 'element' | 'text' | 'fragment' | 'portal'
   tag?: string
   classes?: string[]
   attrs?: Record<string, string>
@@ -38,6 +39,7 @@ interface PreparedInternal {
   layout?: import('./types.js').LayoutProps
   textContent?: string
   textHandle?: unknown
+  portalTarget?: HTMLElement
   children: PreparedInternal[]
   metrics: ComponentMetrics
 }
@@ -89,6 +91,8 @@ function prepareNode(node: ComponentNode, options?: PrepareOptions): PreparedInt
       return prepareElementNode(node, options)
     case 'fragment':
       return prepareFragmentNode(node, options)
+    case 'portal':
+      return preparePortalNode(node, options)
   }
 }
 
@@ -174,6 +178,32 @@ function prepareFragmentNode(node: FragmentNode, options?: PrepareOptions): Prep
   }
 }
 
+function preparePortalNode(node: PortalNode, options?: PrepareOptions): PreparedInternal {
+  const index = allocIndex() // Assign portal's index BEFORE processing children
+
+  const children = node.children.flatMap(child => {
+    const prepared = prepareNode(child, options)
+    if (prepared.nodeType === 'fragment') {
+      return prepared.children
+    }
+    return [prepared]
+  })
+
+  const hasText = children.some(c => c.metrics.hasText)
+
+  return {
+    _index: index,
+    nodeType: 'portal',
+    portalTarget: node.target,
+    children,
+    metrics: {
+      hasText,
+      isInline: false,
+      simpleLayout: true,  // Portal slot is 0×0 — always "simple" from parent's perspective
+    },
+  }
+}
+
 // ============================================================
 // Helpers
 // ============================================================
@@ -195,8 +225,12 @@ export function getMetrics(prepared: PreparedComponent): ComponentMetrics {
   return unbrandPrepared(prepared).metrics
 }
 
-export function getNodeType(prepared: PreparedComponent): 'element' | 'text' | 'fragment' {
+export function getNodeType(prepared: PreparedComponent): 'element' | 'text' | 'fragment' | 'portal' {
   return unbrandPrepared(prepared).nodeType
+}
+
+export function getPortalTarget(prepared: PreparedComponent): HTMLElement | undefined {
+  return unbrandPrepared(prepared).portalTarget
 }
 
 export function getTag(prepared: PreparedComponent): string | undefined {

--- a/src/reflow.ts
+++ b/src/reflow.ts
@@ -16,6 +16,14 @@ import {
   getTextContent,
 } from './prepare.js'
 
+// ============================================================
+// Internal helpers
+// ============================================================
+
+function isPortalNode(prepared: PreparedComponent): boolean {
+  return getNodeType(prepared) === 'portal'
+}
+
 import { measureSimple } from './fast-path.js'
 import { measureFlex } from './flex.js'
 
@@ -63,6 +71,18 @@ function layoutNode(
   const nodeType = getNodeType(prepared)
   const children = getPreparedChildren(prepared)
 
+  // Portal nodes: assign 0×0 to the slot (transparent to parent layout),
+  // then recurse children using the same parent constraints so they get sized
+  // correctly for when they are eventually rendered in the targetElement.
+  if (nodeType === 'portal') {
+    result.width[idx] = 0
+    result.height[idx] = 0
+    for (const child of children) {
+      layoutNode(child, constraints, result, lineHeight)
+    }
+    return
+  }
+
   // Resolve own dimensions
   const ownWidth = layout?.width ?? constraints.maxWidth
   const ownHeight = layout?.height ?? 0
@@ -93,6 +113,12 @@ function layoutNode(
     measureFlex(prepared, childMaxWidth, childMaxHeight, result, lineHeight, layout)
   }
 
+  // Post-process: zero out portal slots and fix sibling y-positions.
+  // The layout functions (measureSimple/measureFlex) don't know about portals —
+  // they treat portal children like normal block nodes. We correct that here by
+  // zeroing the portal slot and re-flowing sibling y-positions excluding portals.
+  fixPortalSlots(children, result)
+
   // Bottom-up: parent height = sum of children heights (column) or max (row)
   // Only calculate if not already set by the layout function (measureFlex/measureSimple)
   if (ownHeight === 0 && result.height[idx] === 0) {
@@ -114,6 +140,40 @@ function layoutNode(
         }
       }
       result.height[idx] = maxHeight
+    }
+  }
+}
+
+/**
+ * After measureSimple/measureFlex runs on a parent, this function zeros out
+ * portal child slots and recalculates sibling y-positions so portals are
+ * invisible to the layout flow (0×0, no offset contribution).
+ *
+ * Portal children are still recursed inside layoutChild (via measureSimple),
+ * so their OWN children get correct sizes for when they render in targetElement.
+ * We only zero the PORTAL SLOT itself, not its children's layout results.
+ */
+function fixPortalSlots(children: PreparedComponent[], result: LayoutResult): void {
+  // Check if any child is a portal — fast-exit for the common case
+  const hasPortal = children.some(c => getNodeType(c) === 'portal')
+  if (!hasPortal) return
+
+  // Recalculate y-positions for all non-portal siblings, accumulating only
+  // the heights of real (non-portal) children.
+  let offsetY = 0
+  for (const child of children) {
+    const childIdx = getNodeIndex(child)
+    if (getNodeType(child) === 'portal') {
+      // Zero the portal slot — it must not occupy parent space
+      result.width[childIdx] = 0
+      result.height[childIdx] = 0
+      result.x[childIdx] = 0
+      result.y[childIdx] = 0
+      // Do NOT advance offsetY — portal contributes no space
+    } else {
+      // Reposition non-portal sibling at the correct (portal-excluded) offset
+      result.y[childIdx] = offsetY
+      offsetY += result.height[childIdx]
     }
   }
 }

--- a/src/reflow.ts
+++ b/src/reflow.ts
@@ -16,14 +16,6 @@ import {
   getTextContent,
 } from './prepare.js'
 
-// ============================================================
-// Internal helpers
-// ============================================================
-
-function isPortalNode(prepared: PreparedComponent): boolean {
-  return getNodeType(prepared) === 'portal'
-}
-
 import { measureSimple } from './fast-path.js'
 import { measureFlex } from './flex.js'
 
@@ -72,13 +64,19 @@ function layoutNode(
   const children = getPreparedChildren(prepared)
 
   // Portal nodes: assign 0×0 to the slot (transparent to parent layout),
-  // then recurse children using the same parent constraints so they get sized
-  // correctly for when they are eventually rendered in the targetElement.
+  // then lay out children in a simple top-to-bottom column at the portal target's origin.
+  // The portal is invisible to its parent, but its own children must be positioned
+  // correctly relative to each other (y-stacked) for when they render in the targetElement.
   if (nodeType === 'portal') {
     result.width[idx] = 0
     result.height[idx] = 0
+    let offsetY = 0
     for (const child of children) {
       layoutNode(child, constraints, result, lineHeight)
+      const childIdx = getNodeIndex(child)
+      result.x[childIdx] = 0
+      result.y[childIdx] = offsetY
+      offsetY += result.height[childIdx]
     }
     return
   }
@@ -113,12 +111,6 @@ function layoutNode(
     measureFlex(prepared, childMaxWidth, childMaxHeight, result, lineHeight, layout)
   }
 
-  // Post-process: zero out portal slots and fix sibling y-positions.
-  // The layout functions (measureSimple/measureFlex) don't know about portals —
-  // they treat portal children like normal block nodes. We correct that here by
-  // zeroing the portal slot and re-flowing sibling y-positions excluding portals.
-  fixPortalSlots(children, result)
-
   // Bottom-up: parent height = sum of children heights (column) or max (row)
   // Only calculate if not already set by the layout function (measureFlex/measureSimple)
   if (ownHeight === 0 && result.height[idx] === 0) {
@@ -140,40 +132,6 @@ function layoutNode(
         }
       }
       result.height[idx] = maxHeight
-    }
-  }
-}
-
-/**
- * After measureSimple/measureFlex runs on a parent, this function zeros out
- * portal child slots and recalculates sibling y-positions so portals are
- * invisible to the layout flow (0×0, no offset contribution).
- *
- * Portal children are still recursed inside layoutChild (via measureSimple),
- * so their OWN children get correct sizes for when they render in targetElement.
- * We only zero the PORTAL SLOT itself, not its children's layout results.
- */
-function fixPortalSlots(children: PreparedComponent[], result: LayoutResult): void {
-  // Check if any child is a portal — fast-exit for the common case
-  const hasPortal = children.some(c => getNodeType(c) === 'portal')
-  if (!hasPortal) return
-
-  // Recalculate y-positions for all non-portal siblings, accumulating only
-  // the heights of real (non-portal) children.
-  let offsetY = 0
-  for (const child of children) {
-    const childIdx = getNodeIndex(child)
-    if (getNodeType(child) === 'portal') {
-      // Zero the portal slot — it must not occupy parent space
-      result.width[childIdx] = 0
-      result.height[childIdx] = 0
-      result.x[childIdx] = 0
-      result.y[childIdx] = 0
-      // Do NOT advance offsetY — portal contributes no space
-    } else {
-      // Reposition non-portal sibling at the correct (portal-excluded) offset
-      result.y[childIdx] = offsetY
-      offsetY += result.height[childIdx]
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export type ComponentNode =
   | ElementNode
   | TextNode
   | FragmentNode
+  | PortalNode
 
 export interface ElementNode {
   type: 'element'
@@ -44,6 +45,12 @@ export interface TextNode {
 
 export interface FragmentNode {
   type: 'fragment'
+  children: ComponentNode[]
+}
+
+export interface PortalNode {
+  type: 'portal'
+  target: HTMLElement
   children: ComponentNode[]
 }
 

--- a/tests/benchmark.test.ts
+++ b/tests/benchmark.test.ts
@@ -112,7 +112,7 @@ describe('benchmark: 1000-node tree', () => {
     const layout = reflow(p, CONSTRAINTS, { lineHeight: 20 })
 
     const root = document.createElement('div')
-    const state: DOMState = { domNodes: [] }
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
 
     const t0 = performance.now()
     commitFull(layout, p, root, state)
@@ -132,7 +132,7 @@ describe('benchmark: 1000-node tree', () => {
     const p = prepare(BenchComp, undefined)
     const layout = reflow(p, CONSTRAINTS, { lineHeight: 20 })
     const root = document.createElement('div')
-    const state: DOMState = { domNodes: [] }
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
     commitFull(layout, p, root, state)
 
     const total = performance.now() - t0

--- a/tests/commit.test.ts
+++ b/tests/commit.test.ts
@@ -161,7 +161,7 @@ describe('commitFull', () => {
     const root = document.createElement('div')
     const domNodes: (HTMLElement | Text | null)[] = []
 
-    commitFull(layout, prepared, root, { domNodes })
+    commitFull(layout, prepared, root, { domNodes, portalRoots: new Map() })
 
     expect(root.children.length).toBe(1)
     expect(root.children[0].tagName.toLowerCase()).toBe('div')
@@ -184,7 +184,7 @@ describe('commitFull', () => {
     const root = document.createElement('div')
     const domNodes: (HTMLElement | Text | null)[] = []
 
-    commitFull(layout, prepared, root, { domNodes })
+    commitFull(layout, prepared, root, { domNodes, portalRoots: new Map() })
 
     const container = root.children[0] as HTMLElement
     expect(container.style.position).toBe('absolute')
@@ -207,7 +207,7 @@ describe('commitFull', () => {
     const root = document.createElement('div')
     const domNodes: (HTMLElement | Text | null)[] = []
 
-    commitFull(layout, prepared, root, { domNodes })
+    commitFull(layout, prepared, root, { domNodes, portalRoots: new Map() })
 
     expect(root.style.position).toBe('relative')
     // overflow is NOT set to hidden — the framework measures and sets explicit

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -66,7 +66,7 @@ describe('edge case: empty tree', () => {
     const p = prepare(Empty, undefined)
     const layout = reflow(p, CONSTRAINTS)
     const root = document.createElement('div')
-    const state: DOMState = { domNodes: [] }
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
     expect(() => commitFull(layout, p, root, state)).not.toThrow()
     expect(root.children.length).toBe(1)
   })

--- a/tests/portal.test.ts
+++ b/tests/portal.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, beforeAll } from 'bun:test'
 import { Window } from 'happy-dom'
 import { createPortal } from '../src/portal.js'
 import { prepare, resetIndexCounter, getNodeIndex, getNodeType, getPreparedChildren } from '../src/prepare.js'
-import { reflow, createLayoutResult } from '../src/reflow.js'
+import { reflow } from '../src/reflow.js'
 import { commitFull } from '../src/commit.js'
 import type { DOMState } from '../src/commit.js'
 import { defineComponent } from '../src/component.js'
@@ -10,6 +10,7 @@ import { signal } from '../src/signals.js'
 import { createApp } from '../src/app.js'
 import { resetScheduler } from '../src/scheduler.js'
 import type { PortalNode, ElementNode } from '../src/types.js'
+import { fullDiff } from '../src/diff.js'
 
 // ============================================================
 // DOM setup for commit/app tests
@@ -256,6 +257,81 @@ describe('reflow — portal layout', () => {
 })
 
 // ============================================================
+// Bug B — fixPortalSlots: portal siblings in flex row layout
+// ============================================================
+
+describe('Bug B — portal in flex row does not displace siblings', () => {
+  let target: HTMLElement
+
+  beforeEach(() => {
+    resetIndexCounter()
+    target = { tagName: 'DIV' } as unknown as HTMLElement
+  })
+
+  test('flex row with two normal children and a portal: normal children have y=0 and correct x', () => {
+    // root (div, flexDirection:'row') → [span-a, portal, span-b]
+    // span-a and span-b must both have y=0 and x values based only on their sizes
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      layout: { flexDirection: 'row' as const },
+      children: [
+        { type: 'element' as const, tag: 'span', layout: { width: 100, height: 50 }, children: [] },
+        createPortal([{ type: 'text' as const, content: 'portal text' }], target),
+        { type: 'element' as const, tag: 'span', layout: { width: 100, height: 50 }, children: [] },
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const result = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+
+    const rootChildren = getPreparedChildren(prepared)
+    // root=0, spanA=1, portal=2, spanB=3
+    const spanAIdx = getNodeIndex(rootChildren[0]!)
+    const portalIdx = getNodeIndex(rootChildren[1]!)
+    const spanBIdx = getNodeIndex(rootChildren[2]!)
+
+    // Portal must be 0×0
+    expect(result.width[portalIdx]).toBe(0)
+    expect(result.height[portalIdx]).toBe(0)
+
+    // Both spans at y=0 (flex row)
+    expect(result.y[spanAIdx]).toBe(0)
+    expect(result.y[spanBIdx]).toBe(0)
+
+    // spanA at x=0, spanB at x=100 (right after spanA, portal contributes nothing)
+    expect(result.x[spanAIdx]).toBe(0)
+    expect(result.x[spanBIdx]).toBe(100)
+  })
+
+  test('justifyContent:center with a portal child: non-portal siblings are centered correctly', () => {
+    // root (div, flexDirection:'row', justifyContent:'center', width:400) → [span-a, portal, span-b]
+    // Each span is 50px wide. Total real content = 100px. Center offset = (400-100)/2 = 150px
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      layout: { flexDirection: 'row' as const, justifyContent: 'center' as const, width: 400, height: 100 },
+      children: [
+        { type: 'element' as const, tag: 'span', layout: { width: 50, height: 40 }, children: [] },
+        createPortal([{ type: 'text' as const, content: 'modal' }], target),
+        { type: 'element' as const, tag: 'span', layout: { width: 50, height: 40 }, children: [] },
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const result = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+
+    const rootChildren = getPreparedChildren(prepared)
+    const spanAIdx = getNodeIndex(rootChildren[0]!)
+    const spanBIdx = getNodeIndex(rootChildren[2]!)
+
+    // With centering and no portal influence: spanA at x=150, spanB at x=200
+    expect(result.x[spanAIdx]).toBe(150)
+    expect(result.x[spanBIdx]).toBe(200)
+  })
+})
+
+// ============================================================
 // Phase 3: Commit — portal DOM rendering (Task 3.1)
 // ============================================================
 
@@ -411,8 +487,10 @@ describe('commitFull — portal children appended to targetElement', () => {
 
     // portalRoots must have one entry tracking the targetElement
     expect(state.portalRoots.size).toBe(1)
-    const [storedTarget] = [...state.portalRoots.values()]
-    expect(storedTarget).toBe(targetEl)
+    const [entry] = [...state.portalRoots.values()]
+    expect(entry!.target).toBe(targetEl)
+    // nodes array must contain the span that was appended to targetEl
+    expect(entry!.nodes).toHaveLength(1)
   })
 })
 
@@ -529,6 +607,114 @@ describe('app shape change — portal DOM cleanup before re-render', () => {
     expect(targetEl.childNodes.length).toBe(2)
 
     app.unmount()
+  })
+})
+
+// ============================================================
+// PR #8 Bug fixes — RED tests (must fail before fix)
+// ============================================================
+
+describe('Bug A1 — portal cleanup does not nuke external DOM', () => {
+  const syncScheduler = (cb: () => void) => cb()
+
+  test('unmounting with body-like target does not remove unrelated children from that target', () => {
+    resetScheduler()
+    // Use a dedicated container that simulates document.body (holds unrelated children)
+    const portalTarget = document.createElement('div')
+
+    // Survivor element that Axiom did NOT create — must survive unmount
+    const survivor = document.createElement('p')
+    portalTarget.appendChild(survivor)
+
+    const root = document.createElement('div')
+
+    const comp = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          portalTarget
+        ),
+      ],
+    }))
+
+    const app = createApp(comp, root, { scheduler: syncScheduler })
+    app.mount()
+
+    // After mount: portalTarget has survivor + span (2 children)
+    expect(portalTarget.childNodes.length).toBe(2)
+
+    app.unmount()
+
+    // After unmount: only the survivor must remain — Axiom must remove only what it added
+    expect(portalTarget.childNodes.length).toBe(1)
+    expect(portalTarget.childNodes[0]).toBe(survivor)
+  })
+})
+
+describe('Bug A2 — portal direct children get proper y positions', () => {
+  test('two direct div children of a portal have stacked y positions (second y > 0)', () => {
+    resetIndexCounter()
+    const target = document.createElement('div')
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [
+            { type: 'element' as const, tag: 'div', children: [{ type: 'text' as const, content: 'first' }] },
+            { type: 'element' as const, tag: 'div', children: [{ type: 'text' as const, content: 'second' }] },
+          ],
+          target
+        ),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+
+    // Get the portal and its children
+    const rootChildren = getPreparedChildren(prepared)
+    const portalPrepared = rootChildren[0]!
+    const portalChildren = getPreparedChildren(portalPrepared)
+
+    const firstIdx = getNodeIndex(portalChildren[0]!)
+    const secondIdx = getNodeIndex(portalChildren[1]!)
+
+    // First child at y=0
+    expect(layout.y[firstIdx]).toBe(0)
+    // Second child must be below the first (y > 0), not stacked at y=0
+    expect(layout.y[secondIdx]).toBeGreaterThan(0)
+  })
+})
+
+describe('Bug A3 — fullDiff insert ops for portal descendants carry portalTarget', () => {
+  test('fullDiff first-render path: insert ops for portal element children have portalTarget set', () => {
+    resetIndexCounter()
+    const targetEl = document.createElement('section')
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetEl
+        ),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+
+    const ops = fullDiff(null, null, prepared, layout, [])
+
+    // The insert op for the portal child (span) must have portalTarget set
+    const insertOps = ops.filter(op => op.type === 'insert' && op.tag === 'span')
+    expect(insertOps).toHaveLength(1)
+    expect(insertOps[0]!.portalTarget).toBe(targetEl)
   })
 })
 

--- a/tests/portal.test.ts
+++ b/tests/portal.test.ts
@@ -1,0 +1,606 @@
+import { describe, test, expect, beforeEach, beforeAll } from 'bun:test'
+import { Window } from 'happy-dom'
+import { createPortal } from '../src/portal.js'
+import { prepare, resetIndexCounter, getNodeIndex, getNodeType, getPreparedChildren } from '../src/prepare.js'
+import { reflow, createLayoutResult } from '../src/reflow.js'
+import { commitFull } from '../src/commit.js'
+import type { DOMState } from '../src/commit.js'
+import { defineComponent } from '../src/component.js'
+import { signal } from '../src/signals.js'
+import { createApp } from '../src/app.js'
+import { resetScheduler } from '../src/scheduler.js'
+import type { PortalNode, ElementNode } from '../src/types.js'
+
+// ============================================================
+// DOM setup for commit/app tests
+// ============================================================
+
+beforeAll(() => {
+  const window = new Window()
+  globalThis.document = window.document as unknown as Document
+  globalThis.HTMLElement = window.HTMLElement as unknown as typeof HTMLElement
+  globalThis.Text = window.Text as unknown as typeof Text
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    cb(0)
+    return 0
+  }) as typeof requestAnimationFrame
+})
+
+// ============================================================
+// Phase 1: Factory tests (Task 1.1)
+// ============================================================
+
+describe('createPortal factory', () => {
+  let target: HTMLElement
+
+  beforeEach(() => {
+    target = { tagName: 'DIV' } as unknown as HTMLElement
+  })
+
+  test('returns a node with type "portal"', () => {
+    const children = [{ type: 'text' as const, content: 'hello' }]
+    const portal = createPortal(children, target)
+
+    expect(portal.type).toBe('portal')
+  })
+
+  test('stores the target element reference', () => {
+    const children = [{ type: 'text' as const, content: 'hello' }]
+    const portal = createPortal(children, target)
+
+    expect(portal.target).toBe(target)
+  })
+
+  test('stores the children array', () => {
+    const children = [
+      { type: 'text' as const, content: 'a' },
+      { type: 'text' as const, content: 'b' },
+    ]
+    const portal = createPortal(children, target)
+
+    expect(portal.children).toBe(children)
+    expect(portal.children).toHaveLength(2)
+  })
+
+  test('different targets produce independent portals', () => {
+    const targetA = { tagName: 'DIV', id: 'a' } as unknown as HTMLElement
+    const targetB = { tagName: 'DIV', id: 'b' } as unknown as HTMLElement
+
+    const portalA = createPortal([{ type: 'text' as const, content: 'A' }], targetA)
+    const portalB = createPortal([{ type: 'text' as const, content: 'B' }], targetB)
+
+    expect(portalA.target).toBe(targetA)
+    expect(portalB.target).toBe(targetB)
+    expect(portalA.target).not.toBe(portalB.target)
+  })
+
+  test('empty children array is accepted', () => {
+    const portal = createPortal([], target)
+
+    expect(portal.type).toBe('portal')
+    expect(portal.children).toHaveLength(0)
+  })
+
+  test('returned object satisfies PortalNode shape', () => {
+    const children = [{ type: 'text' as const, content: 'hello' }]
+    const portal = createPortal(children, target)
+
+    // Type narrowing: if these pass, the shape is correct
+    const p = portal as PortalNode
+    expect(p.type).toBe('portal')
+    expect(p.target).toBe(target)
+    expect(p.children).toHaveLength(1)
+  })
+})
+
+// ============================================================
+// Phase 2: Prepare + Reflow pipeline tests (Task 2.1)
+// ============================================================
+
+describe('prepare — portal node', () => {
+  let target: HTMLElement
+
+  beforeEach(() => {
+    resetIndexCounter()
+    target = { tagName: 'DIV' } as unknown as HTMLElement
+  })
+
+  test('portal node gets an _index allocated by prepare', () => {
+    // A root element containing a portal child
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal([{ type: 'text' as const, content: 'portal text' }], target),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    // Root element is at index 0; portal is its first child at index 1
+    const rootChildren = getPreparedChildren(prepared)
+    expect(rootChildren).toHaveLength(1)
+
+    const portalPrepared = rootChildren[0]
+    const portalIdx = getNodeIndex(portalPrepared)
+    expect(portalIdx).toBe(1)
+  })
+
+  test('portal nodeType is "portal" after prepare', () => {
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal([{ type: 'text' as const, content: 'hello' }], target),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const rootChildren = getPreparedChildren(prepared)
+    const portalPrepared = rootChildren[0]
+
+    expect(getNodeType(portalPrepared)).toBe('portal')
+  })
+
+  test('portal children are recursed and also get indices', () => {
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'text' as const, content: 'child text' }],
+          target
+        ),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const rootChildren = getPreparedChildren(prepared)
+    const portalPrepared = rootChildren[0]
+    const portalChildren = getPreparedChildren(portalPrepared)
+
+    expect(portalChildren).toHaveLength(1)
+    // Portal is at index 1, its text child at index 2
+    expect(getNodeIndex(portalChildren[0])).toBe(2)
+  })
+})
+
+describe('reflow — portal layout', () => {
+  let target: HTMLElement
+
+  beforeEach(() => {
+    resetIndexCounter()
+    target = { tagName: 'DIV' } as unknown as HTMLElement
+  })
+
+  test('portal node gets 0×0 layout dimensions', () => {
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal([{ type: 'text' as const, content: 'hi' }], target),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const result = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+
+    const rootChildren = getPreparedChildren(prepared)
+    const portalPrepared = rootChildren[0]
+    const portalIdx = getNodeIndex(portalPrepared)
+
+    // Portal slot must be 0×0 — it must not occupy space in parent layout
+    expect(result.width[portalIdx]).toBe(0)
+    expect(result.height[portalIdx]).toBe(0)
+  })
+
+  test('sibling nodes after a portal maintain correct positions', () => {
+    // Layout: root (div) → [portal, text]
+    // The text sibling must NOT be affected by the portal's 0×0 slot
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal([{ type: 'text' as const, content: 'portal content' }], target),
+        { type: 'text' as const, content: 'sibling text' },
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const result = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+
+    const rootChildren = getPreparedChildren(prepared)
+    // rootChildren = [portal (idx 1), text (idx 2)]
+    const textSibling = rootChildren[1]
+    const textIdx = getNodeIndex(textSibling)
+
+    // The sibling text node must have a real height (non-zero after layout)
+    expect(result.height[textIdx]).toBeGreaterThan(0)
+
+    // The sibling y-position must be 0 — the portal did not shift it down
+    expect(result.y[textIdx]).toBe(0)
+  })
+
+  test('sibling before AND after portal both get correct layout', () => {
+    // root (div) → [text-a, portal, text-b]
+    const textA: ElementNode = { type: 'element' as const, tag: 'span', children: [{ type: 'text' as const, content: 'A' }] }
+    const textB: ElementNode = { type: 'element' as const, tag: 'span', children: [{ type: 'text' as const, content: 'B' }] }
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        textA,
+        createPortal([{ type: 'text' as const, content: 'hidden' }], target),
+        textB,
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const result = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+
+    const rootChildren = getPreparedChildren(prepared)
+    // root=0, textA=1, portal=2, textB=3+
+
+    const textAIdx = getNodeIndex(rootChildren[0])
+    const portalIdx = getNodeIndex(rootChildren[1])
+    const textBIdx = getNodeIndex(rootChildren[2])
+
+    // Portal is 0×0
+    expect(result.width[portalIdx]).toBe(0)
+    expect(result.height[portalIdx]).toBe(0)
+
+    // Both sibling spans have positive width
+    expect(result.width[textAIdx]).toBeGreaterThan(0)
+    expect(result.width[textBIdx]).toBeGreaterThan(0)
+  })
+})
+
+// ============================================================
+// Phase 3: Commit — portal DOM rendering (Task 3.1)
+// ============================================================
+
+describe('commitFull — portal children appended to targetElement', () => {
+  beforeEach(() => {
+    resetIndexCounter()
+  })
+
+  test('portal children are appended to targetElement, not the parent container', () => {
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetEl
+        ),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
+
+    commitFull(layout, prepared, root, state)
+
+    // The portal child <span> must be in targetEl, NOT in root
+    expect(targetEl.childNodes.length).toBe(1)
+    expect((targetEl.childNodes[0] as HTMLElement).tagName).toBe('SPAN')
+    // Root must NOT contain the portal child — root only has the host div
+    // (portal slot is 0×0 and the span is in targetEl)
+    const rootDiv = root.childNodes[0] as HTMLElement
+    expect(rootDiv.tagName).toBe('DIV')
+    expect(rootDiv.childNodes.length).toBe(0)
+  })
+
+  test('two portals to two different targets each receive their own children', () => {
+    const targetA = document.createElement('section')
+    const targetB = document.createElement('aside')
+    const root = document.createElement('div')
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetA
+        ),
+        createPortal(
+          [{ type: 'element' as const, tag: 'p', children: [] }],
+          targetB
+        ),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
+
+    commitFull(layout, prepared, root, state)
+
+    // targetA gets the <span>
+    expect(targetA.childNodes.length).toBe(1)
+    expect((targetA.childNodes[0] as HTMLElement).tagName).toBe('SPAN')
+
+    // targetB gets the <p>
+    expect(targetB.childNodes.length).toBe(1)
+    expect((targetB.childNodes[0] as HTMLElement).tagName).toBe('P')
+
+    // Root only has the host div; portal children are in their respective targets
+    const hostDiv = root.childNodes[0] as HTMLElement
+    expect(hostDiv.tagName).toBe('DIV')
+    expect(hostDiv.childNodes.length).toBe(0)
+  })
+
+  test('portal with empty children adds nothing to targetElement', () => {
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal([], targetEl),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
+
+    commitFull(layout, prepared, root, state)
+
+    expect(targetEl.childNodes.length).toBe(0)
+  })
+
+  test('two portals targeting the same element both append their children in render order', () => {
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetEl
+        ),
+        createPortal(
+          [{ type: 'element' as const, tag: 'em', children: [] }],
+          targetEl
+        ),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
+
+    commitFull(layout, prepared, root, state)
+
+    // targetEl must contain children from BOTH portals
+    expect(targetEl.childNodes.length).toBe(2)
+    // Render order: first portal's child (span) before second portal's child (em)
+    expect((targetEl.childNodes[0] as HTMLElement).tagName).toBe('SPAN')
+    expect((targetEl.childNodes[1] as HTMLElement).tagName).toBe('EM')
+  })
+
+  test('portalRoots map is populated with portal index → targetElement', () => {
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const component = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetEl
+        ),
+      ],
+    }))
+
+    const prepared = prepare(component, undefined)
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 })
+    const state: DOMState = { domNodes: [], portalRoots: new Map() }
+
+    commitFull(layout, prepared, root, state)
+
+    // portalRoots must have one entry tracking the targetElement
+    expect(state.portalRoots.size).toBe(1)
+    const [storedTarget] = [...state.portalRoots.values()]
+    expect(storedTarget).toBe(targetEl)
+  })
+})
+
+// ============================================================
+// Phase 4: Unmount & Reactivity (Task 4.1)
+// ============================================================
+
+describe('app unmount — portal DOM cleanup', () => {
+  const syncScheduler = (cb: () => void) => cb()
+
+  test('unmounting the app removes portal children from targetElement', () => {
+    resetScheduler()
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const comp = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetEl
+        ),
+      ],
+    }))
+
+    const app = createApp(comp, root, { scheduler: syncScheduler })
+    app.mount()
+
+    // Verify portal content is in targetEl after mount
+    expect(targetEl.childNodes.length).toBe(1)
+
+    app.unmount()
+
+    // After unmount, targetEl must be empty
+    expect(targetEl.childNodes.length).toBe(0)
+  })
+
+  test('unmounting removes portal DOM and does not affect root', () => {
+    resetScheduler()
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const comp = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        { type: 'element' as const, tag: 'p', children: [] },
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetEl
+        ),
+      ],
+    }))
+
+    const app = createApp(comp, root, { scheduler: syncScheduler })
+    app.mount()
+
+    expect(targetEl.childNodes.length).toBe(1)
+
+    app.unmount()
+
+    expect(targetEl.childNodes.length).toBe(0)
+    // Root also cleared
+    expect(root.childNodes.length).toBe(0)
+  })
+})
+
+describe('app shape change — portal DOM cleanup before re-render', () => {
+  const syncScheduler = (cb: () => void) => cb()
+
+  test('shape change clears old portal DOM in targetElement before writing new content', () => {
+    resetScheduler()
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    // Toggle signal to cause a shape change (different child count)
+    const showExtra = signal(false, { kind: 'shape' })
+
+    const comp = defineComponent(() => {
+      const children: ReturnType<typeof createPortal>[] = [
+        createPortal(
+          [{ type: 'element' as const, tag: 'span', children: [] }],
+          targetEl
+        ),
+      ]
+      if (showExtra.value) {
+        children.push(
+          createPortal(
+            [{ type: 'element' as const, tag: 'em', children: [] }],
+            targetEl
+          )
+        )
+      }
+      return {
+        type: 'element' as const,
+        tag: 'div',
+        children,
+      }
+    })
+
+    const app = createApp(comp, root, { scheduler: syncScheduler })
+    app.mount()
+
+    // Initially one portal child in targetEl
+    expect(targetEl.childNodes.length).toBe(1)
+    expect((targetEl.childNodes[0] as HTMLElement).tagName).toBe('SPAN')
+
+    // Shape change: now two portals → targetEl gets two children
+    showExtra.value = true
+
+    // After shape change + re-render: old portal content cleared, new content written
+    // targetEl should have exactly 2 children (SPAN + EM) — no duplicates from stale DOM
+    expect(targetEl.childNodes.length).toBe(2)
+
+    app.unmount()
+  })
+})
+
+describe('portal reactivity — signal update inside portal', () => {
+  const syncScheduler = (cb: () => void) => cb()
+
+  test('updating a signal inside a portal updates the DOM inside targetElement', () => {
+    resetScheduler()
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const text = signal('initial')
+
+    const comp = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'text' as const, content: text.value }],
+          targetEl
+        ),
+      ],
+    }))
+
+    const app = createApp(comp, root, { scheduler: syncScheduler })
+    app.mount()
+
+    // Initial render: targetEl has a text node with "initial"
+    expect(targetEl.childNodes.length).toBe(1)
+    expect((targetEl.childNodes[0] as Text).nodeValue).toBe('initial')
+
+    // Update the signal
+    text.value = 'updated'
+
+    // The text node inside targetEl must reflect the new value
+    expect(targetEl.childNodes.length).toBe(1)
+    expect((targetEl.childNodes[0] as Text).nodeValue).toBe('updated')
+
+    app.unmount()
+  })
+
+  test('signal update in portal does not affect root container content', () => {
+    resetScheduler()
+    const targetEl = document.createElement('section')
+    const root = document.createElement('div')
+
+    const text = signal('hello')
+
+    const comp = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        createPortal(
+          [{ type: 'text' as const, content: text.value }],
+          targetEl
+        ),
+        { type: 'element' as const, tag: 'p', children: [] },
+      ],
+    }))
+
+    const app = createApp(comp, root, { scheduler: syncScheduler })
+    app.mount()
+
+    const rootChildCount = root.childNodes.length
+
+    text.value = 'world'
+
+    // Root structure unchanged — same number of children
+    expect(root.childNodes.length).toBe(rootChildCount)
+    // targetEl has updated content
+    expect((targetEl.childNodes[0] as Text).nodeValue).toBe('world')
+
+    app.unmount()
+  })
+})


### PR DESCRIPTION
Closes #7

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Summary

- Add `createPortal(children, targetElement): PortalNode` - renders component children into any DOM node outside the app root while preserving reactivity and lifecycle
- Implement `PortalNode` as a first-class node type: transparent to layout (0x0), redirected in commit phase to targetElement
- Refactor `applyOps` in commit.ts to support per-container DocumentFragment batching via Map<HTMLElement, DocumentFragment>
- Add automatic portal DOM cleanup on shape-change and unmount via DOMState.portalRoots
- Add modal demo in demo/portal-demo.ts showcasing portal with signal-controlled open/close state

## Changes

| File | Change |
|------|--------|
| src/portal.ts | New - createPortal factory |
| src/types.ts | Add PortalNode to ComponentNode union; portalRoots to DOMState |
| src/prepare.ts | Handle 'portal' node type - allocate index, store portalTarget, recurse children |
| src/reflow.ts | 0x0 layout for portal slot via fixPortalSlots post-processor |
| src/commit.ts | Portal branch in buildDOMTree; multi-target applyOps refactor |
| src/app.ts | Clear portalRoots on shape-change and unmount |
| src/index.ts | Export createPortal and PortalNode |
| tests/portal.test.ts | 22 tests - 8/8 spec scenarios covered |
| demo/portal-demo.ts | New - modal demo using createPortal into document.body |
| demo/style.css | Portal/modal styles with backdrop blur and animations |

## Test Plan

- [x] bun test - 225 pass, 0 fail
- [x] bun run typecheck - clean, 0 errors
- [x] 8/8 spec scenarios compliant (SDD verify)
- [x] Demo implemented and typechecks clean

## Summary by Sourcery

Agregar soporte de portales para renderizar componentes en contenedores DOM arbitrarios fuera de la raíz de la app, manteniendo intactos el layout y el ciclo de vida.

Nuevas funcionalidades:
- Introducir un tipo `PortalNode` y la factoría `createPortal` para renderizar elementos secundarios en un `HTMLElement` específico fuera del árbol principal de componentes.
- Agregar una app de demostración independiente de portales que muestra un modal controlado por signals, renderizado en `document.body` mediante `createPortal`.

Mejoras:
- Extender las fases de layout y prepare para reconocer nodos de portal, tratar sus slots como de 0×0 en el layout del padre y dimensionar correctamente sus elementos secundarios según el destino del portal.
- Refinar la lógica de commit al DOM para admitir inserciones agrupadas por contenedor y rastrear los elementos raíz de portales para su limpieza cuando cambie la forma del árbol o durante los unmounts.

Tests:
- Agregar una suite de tests dedicada a portales y actualizar los tests y benchmarks existentes para que funcionen con el estado extendido del DOM que incluye raíces de portal.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add portal support to render components into arbitrary DOM containers outside the app root while keeping layout and lifecycle intact.

New Features:
- Introduce a PortalNode type and createPortal factory for rendering children into a specified HTMLElement outside the main component tree.
- Add a standalone portal demo app showcasing a signal-controlled modal rendered into document.body via createPortal.

Enhancements:
- Extend the layout and prepare phases to recognize portal nodes, treat their slots as 0×0 in parent layout, and size their children correctly for the portal target.
- Refine DOM commit logic to support per-container batched inserts and to track portal root elements for cleanup on shape changes and unmounts.

Tests:
- Add dedicated portal test suite and update existing tests and benchmarks to work with the extended DOM state that includes portal roots.

</details>