### PR TITLE
refactor(text): rename pretext contract to TextLayoutEngine

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,5 @@
 import type { ComponentDefinition, LayoutConstraints, LayoutResult, PreparedComponent } from './types.js'
-import type { PretextModule, PrepareOptions } from './prepare.js'
+import type { TextLayoutEngine, PrepareOptions } from './prepare.js'
 import type { SchedulerFn } from './scheduler.js'
 import type { ReflowOptions } from './reflow.js'
 import type { Router } from './router.js'
@@ -40,7 +40,7 @@ export interface RenderMetrics {
 export interface AppOptions {
   lineHeight?: number
   font?: string
-  pretext?: PretextModule
+  textEngine?: TextLayoutEngine
   scheduler?: SchedulerFn
   router?: Router
 }
@@ -76,7 +76,7 @@ export function createApp(
 
   const prepareOpts: PrepareOptions = {
     font: options?.font ?? '16px sans-serif',
-    pretext: options?.pretext,
+    textEngine: options?.textEngine,
   }
 
   const reflowOpts: ReflowOptions = {

--- a/src/fast-path.ts
+++ b/src/fast-path.ts
@@ -104,7 +104,7 @@ function measureText(
   const idx = getNodeIndex(prepared)
   const textHandle = getTextHandle(prepared)
 
-  // Resolve text content — prefer pretext handle, fallback to raw textContent
+  // Resolve text content — prefer text engine handle, fallback to raw textContent
   let text: string | undefined
   if (textHandle !== undefined) {
     text = (textHandle as { text: string }).text

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -10,17 +10,17 @@ import type {
 } from './types.js'
 
 // ============================================================
-// Pretext integration type
+// Text layout engine contract
 // ============================================================
 
-export interface PretextModule {
+export interface TextLayoutEngine {
   prepare(text: string, font: string): unknown
   layout(prepared: unknown, maxWidth: number, lineHeight: number): { lineCount: number; height: number }
   clearCache(): void
 }
 
 export interface PrepareOptions {
-  pretext?: PretextModule
+  textEngine?: TextLayoutEngine
   font?: string
 }
 
@@ -97,11 +97,11 @@ function prepareNode(node: ComponentNode, options?: PrepareOptions): PreparedInt
 }
 
 function prepareTextNode(node: TextNode, options?: PrepareOptions): PreparedInternal {
-  const pretext = options?.pretext
+  const textEngine = options?.textEngine
   let textHandle: unknown = undefined
 
-  if (pretext !== undefined) {
-    textHandle = pretext.prepare(node.content, options?.font ?? '16px sans-serif')
+  if (textEngine !== undefined) {
+    textHandle = textEngine.prepare(node.content, options?.font ?? '16px sans-serif')
   }
 
   return {

--- a/src/reflow.ts
+++ b/src/reflow.ts
@@ -136,7 +136,7 @@ function layoutText(
   const idx = getNodeIndex(prepared)
   const textHandle = getTextHandle(prepared)
 
-  // Resolve text content — prefer pretext handle, fallback to raw textContent
+  // Resolve text content — prefer text engine handle, fallback to raw textContent
   let text: string | undefined
   if (textHandle !== undefined) {
     text = (textHandle as { text: string }).text

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export interface ComponentMetrics {
   simpleLayout: boolean
 }
 
-// Brand type — opaque handle, like PreparedText from pretext
+// Brand type — opaque prepared component handle
 declare const preparedBrand: unique symbol
 
 export type PreparedComponent = {

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -27,10 +27,10 @@ beforeAll(() => {
 })
 
 // ============================================================
-// Fake pretext
+// Fake text layout engine
 // ============================================================
 
-const fakePretext = {
+const fakeTextEngine = {
   prepare: (text: string, _font: string) => ({ text }),
   layout: (_p: unknown, maxWidth: number, _lh: number) => {
     const text = (_p as { text: string }).text
@@ -54,7 +54,7 @@ describe('createApp', () => {
     }))
 
     const root = document.createElement('div')
-    const app = createApp(comp, root, { pretext: fakePretext })
+    const app = createApp(comp, root, { textEngine: fakeTextEngine })
 
     expect(typeof app.mount).toBe('function')
     expect(typeof app.unmount).toBe('function')
@@ -70,7 +70,7 @@ describe('createApp', () => {
     }))
 
     const root = document.createElement('div')
-    const app = createApp(comp, root, { pretext: fakePretext })
+    const app = createApp(comp, root, { textEngine: fakeTextEngine })
     app.mount()
 
     expect(root.childNodes.length).toBe(1)
@@ -88,7 +88,7 @@ describe('createApp', () => {
     }))
 
     const root = document.createElement('div')
-    const app = createApp(comp, root, { pretext: fakePretext })
+    const app = createApp(comp, root, { textEngine: fakeTextEngine })
     app.mount()
     expect(root.childNodes.length).toBeGreaterThan(0)
 
@@ -104,7 +104,7 @@ describe('createApp', () => {
     }))
 
     const root = document.createElement('div')
-    const app = createApp(comp, root, { pretext: fakePretext })
+    const app = createApp(comp, root, { textEngine: fakeTextEngine })
     app.mount()
 
     const metrics = app.getMetrics()
@@ -127,7 +127,7 @@ describe('createApp', () => {
 
     const root = document.createElement('div')
     const app = createApp(comp, root, {
-      pretext: fakePretext,
+      textEngine: fakeTextEngine,
       scheduler: mockScheduler,
     })
     app.mount()

--- a/tests/commit.test.ts
+++ b/tests/commit.test.ts
@@ -14,10 +14,10 @@ beforeAll(() => {
 })
 
 // ============================================================
-// Fake pretext
+// Fake text layout engine
 // ============================================================
 
-const fakePretext = {
+const fakeTextEngine = {
   prepare: (text: string, _font: string) => ({ text }),
   layout: (_p: unknown, maxWidth: number, _lh: number) => {
     const text = (_p as { text: string }).text
@@ -155,7 +155,7 @@ describe('commitFull', () => {
       ]
     }))
 
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const layout = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: 20 })
 
     const root = document.createElement('div')
@@ -178,7 +178,7 @@ describe('commitFull', () => {
       ]
     }))
 
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const layout = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: 20 })
 
     const root = document.createElement('div')
@@ -201,7 +201,7 @@ describe('commitFull', () => {
       ]
     }))
 
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const layout = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: 20 })
 
     const root = document.createElement('div')

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -21,10 +21,10 @@ beforeAll(() => {
 })
 
 // ============================================================
-// Fake pretext
+// Fake text layout engine
 // ============================================================
 
-const fakePretext = {
+const fakeTextEngine = {
   prepare: (text: string, _font: string) => ({ text }),
   layout: (_p: unknown, maxWidth: number, _lh: number) => {
     const text = (_p as { text: string }).text
@@ -93,7 +93,7 @@ describe('fullDiff', () => {
         { type: 'text' as const, content: 'Hello' }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const layout = createLayoutResult(prepared)
 
     const ops = fullDiff(null, null, prepared, layout, [])
@@ -109,14 +109,14 @@ describe('fullDiff', () => {
         { type: 'text' as const, content: 'Hello' }
       ]
     }))
-    const prevPrepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prevPrepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const prevLayout = createLayoutResult(prevPrepared)
     prevLayout.x[1] = 0
     prevLayout.y[1] = 0
     prevLayout.width[1] = 500
     prevLayout.height[1] = 20
 
-    const newPrepared = prepare(comp, undefined, { pretext: fakePretext })
+    const newPrepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const newLayout = createLayoutResult(newPrepared)
     newLayout.x[1] = 100
     newLayout.y[1] = 50
@@ -147,9 +147,9 @@ describe('fullDiff', () => {
       ]
     }))
 
-    const prevPrepared = prepare(comp1, undefined, { pretext: fakePretext })
+    const prevPrepared = prepare(comp1, undefined, { textEngine: fakeTextEngine })
     const prevLayout = createLayoutResult(prevPrepared)
-    const newPrepared = prepare(comp2, undefined, { pretext: fakePretext })
+    const newPrepared = prepare(comp2, undefined, { textEngine: fakeTextEngine })
     const newLayout = createLayoutResult(newPrepared)
 
     const domNodes: (HTMLElement | Text | null)[] = [
@@ -181,9 +181,9 @@ describe('fullDiff', () => {
       ]
     }))
 
-    const prevPrepared = prepare(comp1, undefined, { pretext: fakePretext })
+    const prevPrepared = prepare(comp1, undefined, { textEngine: fakeTextEngine })
     const prevLayout = createLayoutResult(prevPrepared)
-    const newPrepared = prepare(comp2, undefined, { pretext: fakePretext })
+    const newPrepared = prepare(comp2, undefined, { textEngine: fakeTextEngine })
     const newLayout = createLayoutResult(newPrepared)
 
     const domNodes: (HTMLElement | Text | null)[] = [
@@ -225,9 +225,9 @@ describe('fullDiff', () => {
       ]
     }))
 
-    const prevPrepared = prepare(comp1, undefined, { pretext: fakePretext })
+    const prevPrepared = prepare(comp1, undefined, { textEngine: fakeTextEngine })
     const prevLayout = createLayoutResult(prevPrepared)
-    const newPrepared = prepare(comp2, undefined, { pretext: fakePretext })
+    const newPrepared = prepare(comp2, undefined, { textEngine: fakeTextEngine })
     const newLayout = createLayoutResult(newPrepared)
 
     const domNodes: (HTMLElement | Text | null)[] = [

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -5,10 +5,10 @@ import { signal, computed, effect, defineComponent, prepare } from '../src/index
 import type { ComponentNode } from '../src/index.js'
 
 // ============================================================
-// Fake pretext
+// Fake text layout engine
 // ============================================================
 
-const fakePretext = {
+const fakeTextEngine = {
   prepare: mock((text: string, _font: string) => ({ text })),
   layout: mock((_p: unknown, _w: number, lh: number) => ({ lineCount: 1, height: lh })),
   clearCache: mock(),
@@ -30,7 +30,7 @@ describe('integration: signal triggers prepare', () => {
     }))
 
     effect(() => {
-      const p = prepare(comp, { value: count.value }, { pretext: fakePretext })
+      const p = prepare(comp, { value: count.value }, { textEngine: fakeTextEngine })
       preparedCount++
       expect(p).toBeDefined()
     })
@@ -49,11 +49,11 @@ describe('integration: signal triggers prepare', () => {
       children: [{ type: 'text' as const, content: `Hello ${name.value}!` }]
     }))
 
-    const p1 = prepare(comp, undefined, { pretext: fakePretext })
+    const p1 = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(p1).toBeDefined()
 
     name.value = 'Axiom'
-    const p2 = prepare(comp, undefined, { pretext: fakePretext })
+    const p2 = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(p2).toBeDefined()
   })
 
@@ -68,11 +68,11 @@ describe('integration: signal triggers prepare', () => {
       }))
     }))
 
-    const p1 = prepare(comp, undefined, { pretext: fakePretext })
+    const p1 = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(p1).toBeDefined()
 
     items.value = ['a', 'b', 'c']
-    const p2 = prepare(comp, undefined, { pretext: fakePretext })
+    const p2 = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(p2).toBeDefined()
   })
 
@@ -88,7 +88,7 @@ describe('integration: signal triggers prepare', () => {
 
     let lastValue = 0
     effect(() => {
-      const p = prepare(comp, { value: doubled.value }, { pretext: fakePretext })
+      const p = prepare(comp, { value: doubled.value }, { textEngine: fakeTextEngine })
       expect(p).toBeDefined()
       lastValue = doubled.value
     })
@@ -115,7 +115,7 @@ describe('integration: signal triggers prepare', () => {
     let prepareCalls = 0
     effect(() => {
       void count.value // track computed
-      const p = prepare(List, undefined, { pretext: fakePretext })
+      const p = prepare(List, undefined, { textEngine: fakeTextEngine })
       prepareCalls++
       expect(p).toBeDefined()
     })

--- a/tests/prepare.test.ts
+++ b/tests/prepare.test.ts
@@ -4,12 +4,12 @@ import { prepare } from '../src/prepare.js'
 import type { ComponentNode } from '../src/types.js'
 
 // ============================================================
-// Fake pretext module — mimics pretext's prepare() API
+// Fake text layout engine — mimics the TextLayoutEngine contract
 // ============================================================
 
 const fakePreparedText = Symbol('fake-prepared-text')
 
-const fakePretext = {
+const fakeTextEngine = {
   prepare: mock((text: string, _font: string) => {
     return { [fakePreparedText]: true, text, segmentCount: text.length }
   }),
@@ -19,9 +19,7 @@ const fakePretext = {
   clearCache: mock(),
 }
 
-// Inject fake pretext into module resolution
-// In Phase 1, prepare.ts imports pretext directly, so we mock at the module level
-// For now, we pass the fake pretext as a parameter to prepare() for testability
+// The text engine is injected via PrepareOptions — no module mocking needed
 
 describe('prepare', () => {
   test('prepares a text node', () => {
@@ -30,7 +28,7 @@ describe('prepare', () => {
       content: 'Hello World'
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -43,7 +41,7 @@ describe('prepare', () => {
       children: []
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -59,7 +57,7 @@ describe('prepare', () => {
       ]
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -72,7 +70,7 @@ describe('prepare', () => {
       ]
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -82,7 +80,7 @@ describe('prepare', () => {
       content: 'Hello'
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -95,7 +93,7 @@ describe('prepare', () => {
       ]
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -108,7 +106,7 @@ describe('prepare', () => {
       ]
     }))
 
-    const result = prepare(inlineComp, undefined, { pretext: fakePretext })
+    const result = prepare(inlineComp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -121,7 +119,7 @@ describe('prepare', () => {
       ]
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -132,7 +130,7 @@ describe('prepare', () => {
       children: []
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -142,7 +140,7 @@ describe('prepare', () => {
       content: 'no props'
     }))
 
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 
@@ -157,7 +155,7 @@ describe('prepare', () => {
     }
 
     const comp = defineComponent(() => buildTree(20))
-    const result = prepare(comp, undefined, { pretext: fakePretext })
+    const result = prepare(comp, undefined, { textEngine: fakeTextEngine })
     expect(result).toBeDefined()
   })
 })

--- a/tests/reflow.test.ts
+++ b/tests/reflow.test.ts
@@ -5,10 +5,10 @@ import { reflow, createLayoutResult } from '../src/reflow.js'
 import type { PreparedComponent } from '../src/types.js'
 
 // ============================================================
-// Fake pretext
+// Fake text layout engine
 // ============================================================
 
-const fakePretext = {
+const fakeTextEngine = {
   prepare: mock((text: string, _font: string) => ({ text })),
   layout: mock((_prepared: unknown, maxWidth: number, _lineHeight: number) => {
     // Simulate text wrapping — used by prepare() for metrics, not by fast-path measureText
@@ -33,7 +33,7 @@ function prepareSimple(content: string) {
     tag: 'div',
     children: [{ type: 'text' as const, content }]
   }))
-  return prepare(comp, undefined, { pretext: fakePretext })
+  return prepare(comp, undefined, { textEngine: fakeTextEngine })
 }
 
 describe('createLayoutResult', () => {
@@ -58,7 +58,7 @@ describe('createLayoutResult', () => {
         ]}
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = createLayoutResult(prepared)
 
     expect(result.nodeCount).toBe(3) // root + child + text
@@ -107,7 +107,7 @@ describe('reflow — fast path', () => {
         { type: 'text' as const, content: 'Line 2' }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     // First child at y=0
@@ -125,7 +125,7 @@ describe('reflow — fast path', () => {
         { type: 'text' as const, content: 'B' }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     expect(result.height[0]).toBe(result.height[1] + result.height[2])
@@ -137,7 +137,7 @@ describe('reflow — fast path', () => {
       tag: 'div',
       children: []
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     expect(result.width[0]).toBe(500)
@@ -156,7 +156,7 @@ describe('reflow — flex layout', () => {
         { type: 'element' as const, tag: 'div', layout: { width: 100, height: 50 } }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     // First child at x=0
@@ -178,7 +178,7 @@ describe('reflow — flex layout', () => {
         { type: 'element' as const, tag: 'div', layout: { width: 100, height: 50 } }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     expect(result.x[1]).toBe(0)
@@ -194,7 +194,7 @@ describe('reflow — flex layout', () => {
         { type: 'element' as const, tag: 'div', layout: { width: 100, height: 50 } }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     // Free space = 200 - 50 = 150, center = 75
@@ -211,7 +211,7 @@ describe('reflow — flex layout', () => {
         { type: 'element' as const, tag: 'div', layout: { width: 100, height: 50 } }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     // First at top, last at bottom
@@ -228,7 +228,7 @@ describe('reflow — flex layout', () => {
         { type: 'element' as const, tag: 'div', layout: { width: 50, height: 40 } }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     // Cross axis center: (100 - 40) / 2 = 30
@@ -244,7 +244,7 @@ describe('reflow — flex layout', () => {
         { type: 'text' as const, content: 'Hello' }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 500, maxHeight: 1000 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     // Child positioned at x=20, y=20 (padding offset)
@@ -262,7 +262,7 @@ describe('reflow — edge cases', () => {
       tag: 'div',
       children: []
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 0, maxHeight: 0 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     expect(result.width[0]).toBe(0)
@@ -277,7 +277,7 @@ describe('reflow — edge cases', () => {
         { type: 'text' as const, content: 'Hello' }
       ]
     }))
-    const prepared = prepare(comp, undefined, { pretext: fakePretext })
+    const prepared = prepare(comp, undefined, { textEngine: fakeTextEngine })
     const result = reflow(prepared, { maxWidth: 0, maxHeight: 0 }, { lineHeight: DEFAULT_LINE_HEIGHT })
 
     expect(result.width[0]).toBe(0)

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -23,7 +23,7 @@ function setupDOM() {
   return window
 }
 
-const fakePretext = {
+const fakeTextEngine = {
   prepare: (text: string, _font: string) => ({ text }),
   layout: (_p: unknown, _maxWidth: number, lh: number) => ({ lineCount: 1, height: lh }),
   clearCache: () => {},
@@ -362,7 +362,7 @@ describe('router: app + async integration (RED)', () => {
     const Root = makeComponent('Root')
     const rootEl = document.createElement('div')
 
-    const appNoRouter = createApp(Root, rootEl, { pretext: fakePretext })
+    const appNoRouter = createApp(Root, rootEl, { textEngine: fakeTextEngine })
     expect(() => {
       appNoRouter.mount()
       appNoRouter.unmount()
@@ -370,7 +370,7 @@ describe('router: app + async integration (RED)', () => {
 
     const Home = makeComponent('Home')
     const router = createRouter([{ path: '/', component: Home }])
-    const appWithRouter = createApp(Root, rootEl, { pretext: fakePretext, router })
+    const appWithRouter = createApp(Root, rootEl, { textEngine: fakeTextEngine, router })
 
     expect(() => {
       appWithRouter.mount()
@@ -383,7 +383,7 @@ describe('router: app + async integration (RED)', () => {
 
     try {
       const appWithRouterCleanup = createApp(Root, rootEl, {
-        pretext: fakePretext,
+        textEngine: fakeTextEngine,
         router,
       })
 
@@ -467,7 +467,7 @@ describe('router: app + async integration (RED)', () => {
     })
 
     const rootEl = document.createElement('div')
-    const app = createApp(Root, rootEl, { pretext: fakePretext, router })
+    const app = createApp(Root, rootEl, { textEngine: fakeTextEngine, router })
 
     app.mount()
     router.push('/async')


### PR DESCRIPTION
## Summary
Refactors text layout naming to decouple Axiom API from provider-specific terminology.

## Type of change
- [x] refactor — no behavior change
- [ ] fix — bug fix (patch bump)
- [ ] feat — new feature (minor bump)
- [ ] feat! / BREAKING CHANGE — breaking change (major bump)
- [ ] perf — performance improvement (patch bump)
- [ ] test — tests only
- [ ] docs — documentation only
- [ ] ci — workflow changes
- [ ] chore — maintenance

## Checklist
- [x] Tests added or updated for the changed behavior
- [x] bun test passes locally (all tests green)
- [x] Bun run typecheck passes locally
- [x] Commit messages follow Conventional Commits format
- [x] Hot path invariant respected: no DOM reads added
- [x] No runtime dependencies added to src/

## Related issues\nCloses #14

## Testing notes
- bun run typecheck
- bun test

## Summary by Sourcery

Renombrar el contrato de integración de diseño de texto desde la nomenclatura específica de pretext a un genérico `TextLayoutEngine` en todas las APIs principales y pruebas.

Mejoras:
- Actualizar las opciones de prepare y de la aplicación para usar una interfaz genérica `TextLayoutEngine` en lugar de la nomenclatura específica `PretextModule`.
- Actualizar comentarios internos y el _type branding_ para describir un motor genérico de composición de texto en lugar de un proveedor específico.

Pruebas:
- Ajustar las pruebas unitarias, de integración, de enrutamiento y de la aplicación para inyectar un motor de composición de texto falso mediante la nueva opción `textEngine` en lugar del mock de pretext.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Rename the text layout integration contract from the pretext-specific naming to a generic TextLayoutEngine across core APIs and tests.

Enhancements:
- Update prepare and app options to use a generic TextLayoutEngine interface instead of the pretext-specific PretextModule naming.
- Refresh internal comments and type branding to describe a generic text layout engine rather than a specific provider.

Tests:
- Adjust unit, integration, routing, and app tests to inject a fake text layout engine via the new textEngine option instead of the pretext mock.

</details>