### PR TITLE
feat(ssr): add renderToString public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,10 @@ export type { Route, RouteState, Router } from './router.js'
 export { prepare } from './prepare.js'
 export { reflow } from './reflow.js'
 
+// --- SSR ---
+export { renderToString } from './ssr.js'
+export type { SSRMetadata, SSRRenderOptions } from './ssr.js'
+
 // --- Context ---
 export {
   createContext,

--- a/src/ssr.ts
+++ b/src/ssr.ts
@@ -34,12 +34,30 @@ export interface SSRRenderOptions {
    * integra aún al matching de rutas en servidor.
    */
   url?: string
+  /** ID del elemento raíz donde se monta la app. Por defecto: `"app"`. */
+  rootId?: string
 }
 
-export async function renderToString(
+// Elementos HTML que no tienen closing tag ni pueden tener hijos.
+const VOID_ELEMENTS = new Set([
+  'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+  'link', 'meta', 'param', 'source', 'track', 'wbr',
+])
+
+// Nombre de tag HTML/custom-element válido (e.g. "div", "my-component").
+const VALID_TAG_RE = /^[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*$/
+
+// Nombre de atributo HTML válido (e.g. "data-role", "aria-label").
+const VALID_ATTR_RE = /^[A-Za-z_][\w:.-]*$/
+
+function sanitizeTagName(tag: string): string {
+  return VALID_TAG_RE.test(tag) ? tag : 'div'
+}
+
+export function renderToString(
   component: ComponentDefinition<void>,
   options?: SSRRenderOptions
-): Promise<string> {
+): string {
   const prepared = prepare(component, undefined, {
     font: options?.font ?? '16px sans-serif',
     textEngine: options?.textEngine,
@@ -56,13 +74,18 @@ export async function renderToString(
     }
   )
 
+  const rootId = escapeHtml(options?.rootId ?? 'app')
   const bodyHtml = renderNode(prepared, layout)
   const headHtml = renderHead(options?.metadata)
 
-  return `<!DOCTYPE html><html><head>${headHtml}</head><body><div id="app">${bodyHtml}</div></body></html>`
+  return `<!DOCTYPE html><html><head>${headHtml}</head><body><div id="${rootId}">${bodyHtml}</div></body></html>`
 }
 
-function renderNode(node: PreparedComponent, layout: LayoutResult): string {
+function renderNode(
+  node: PreparedComponent,
+  layout: LayoutResult,
+  isPortalChild = false
+): string {
   const nodeType = getNodeType(node)
 
   if (nodeType === 'text') {
@@ -71,11 +94,16 @@ function renderNode(node: PreparedComponent, layout: LayoutResult): string {
 
   const children = getPreparedChildren(node)
 
-  if (nodeType === 'fragment' || nodeType === 'portal') {
-    return children.map(child => renderNode(child, layout)).join('')
+  if (nodeType === 'fragment') {
+    return children.map(child => renderNode(child, layout, isPortalChild)).join('')
   }
 
-  const tag = getTag(node) ?? 'div'
+  if (nodeType === 'portal') {
+    // Los hijos de portal son gestionados por CSS — el layout del framework no aplica.
+    return children.map(child => renderNode(child, layout, true)).join('')
+  }
+
+  const tag = sanitizeTagName(getTag(node) ?? 'div')
   const attrs = getAttrs(node)
   const classes = getClasses(node)
   const idx = getNodeIndex(node)
@@ -86,14 +114,25 @@ function renderNode(node: PreparedComponent, layout: LayoutResult): string {
     attrPairs.push(['class', classes.join(' ')])
   }
 
-  const style = `left:${layout.x[idx]}px;top:${layout.y[idx]}px;width:${layout.width[idx]}px;height:${layout.height[idx]}px;`
-  attrPairs.push(['style', style])
+  // Emitir el mismo contrato de layout que el renderer de cliente: position:absolute + transform.
+  // Los portal children son CSS-managed (reflow les asigna 0×0), así que se omite el layout.
+  if (!isPortalChild) {
+    let style = `position:absolute;left:0px;top:0px;transform:translate(${layout.x[idx]}px,${layout.y[idx]}px);width:${layout.width[idx]}px;height:${layout.height[idx]}px;`
+    if (attrs?.style) {
+      style += attrs.style.endsWith(';') ? ` ${attrs.style}` : ` ${attrs.style};`
+    }
+    attrPairs.push(['style', style])
+  } else if (attrs?.style) {
+    attrPairs.push(['style', attrs.style])
+  }
 
   if (attrs !== undefined) {
     const keys = Object.keys(attrs).sort()
     for (const key of keys) {
       if (key === 'class' || key === 'style') continue
       if (key.startsWith('on')) continue
+      // Validar nombre de atributo para prevenir inyección de markup.
+      if (!VALID_ATTR_RE.test(key)) continue
       attrPairs.push([key, attrs[key]!])
     }
   }
@@ -106,7 +145,12 @@ function renderNode(node: PreparedComponent, layout: LayoutResult): string {
     ? `<${tag} ${serializedAttrs}>`
     : `<${tag}>`
 
-  const inner = children.map(child => renderNode(child, layout)).join('')
+  // Los elementos void no tienen closing tag ni pueden tener hijos (HTML5).
+  if (VOID_ELEMENTS.has(tag)) {
+    return openTag
+  }
+
+  const inner = children.map(child => renderNode(child, layout, isPortalChild)).join('')
   return `${openTag}${inner}</${tag}>`
 }
 

--- a/src/ssr.ts
+++ b/src/ssr.ts
@@ -1,0 +1,143 @@
+import type { ComponentDefinition, PreparedComponent, LayoutResult } from './types.js'
+import type { TextLayoutEngine } from './prepare.js'
+
+import {
+  prepare,
+  getNodeType,
+  getTag,
+  getTextContent,
+  getClasses,
+  getAttrs,
+  getPreparedChildren,
+  getNodeIndex,
+} from './prepare.js'
+import { reflow } from './reflow.js'
+
+export interface SSRMetadata {
+  title?: string
+  description?: string
+  og?: Record<string, string>
+}
+
+export interface SSRRenderOptions {
+  width?: number
+  height?: number
+  lineHeight?: number
+  font?: string
+  textEngine?: TextLayoutEngine
+  metadata?: SSRMetadata
+  /**
+   * URL inicial para SSR.
+   *
+   * Nota v0.2.6: el router actual depende de `window` y no es SSR-safe,
+   * por lo que este valor se acepta como parte del contrato pero no se
+   * integra aún al matching de rutas en servidor.
+   */
+  url?: string
+}
+
+export async function renderToString(
+  component: ComponentDefinition<void>,
+  options?: SSRRenderOptions
+): Promise<string> {
+  const prepared = prepare(component, undefined, {
+    font: options?.font ?? '16px sans-serif',
+    textEngine: options?.textEngine,
+  })
+
+  const layout = reflow(
+    prepared,
+    {
+      maxWidth: options?.width ?? 800,
+      maxHeight: options?.height ?? 600,
+    },
+    {
+      lineHeight: options?.lineHeight ?? 20,
+    }
+  )
+
+  const bodyHtml = renderNode(prepared, layout)
+  const headHtml = renderHead(options?.metadata)
+
+  return `<!DOCTYPE html><html><head>${headHtml}</head><body><div id="app">${bodyHtml}</div></body></html>`
+}
+
+function renderNode(node: PreparedComponent, layout: LayoutResult): string {
+  const nodeType = getNodeType(node)
+
+  if (nodeType === 'text') {
+    return escapeHtml(getTextContent(node) ?? '')
+  }
+
+  const children = getPreparedChildren(node)
+
+  if (nodeType === 'fragment' || nodeType === 'portal') {
+    return children.map(child => renderNode(child, layout)).join('')
+  }
+
+  const tag = getTag(node) ?? 'div'
+  const attrs = getAttrs(node)
+  const classes = getClasses(node)
+  const idx = getNodeIndex(node)
+
+  const attrPairs: Array<[string, string]> = []
+
+  if (classes !== undefined && classes.length > 0) {
+    attrPairs.push(['class', classes.join(' ')])
+  }
+
+  const style = `left:${layout.x[idx]}px;top:${layout.y[idx]}px;width:${layout.width[idx]}px;height:${layout.height[idx]}px;`
+  attrPairs.push(['style', style])
+
+  if (attrs !== undefined) {
+    const keys = Object.keys(attrs).sort()
+    for (const key of keys) {
+      if (key === 'class' || key === 'style') continue
+      if (key.startsWith('on')) continue
+      attrPairs.push([key, attrs[key]!])
+    }
+  }
+
+  const serializedAttrs = attrPairs
+    .map(([key, value]) => `${key}="${escapeHtml(value)}"`)
+    .join(' ')
+
+  const openTag = serializedAttrs.length > 0
+    ? `<${tag} ${serializedAttrs}>`
+    : `<${tag}>`
+
+  const inner = children.map(child => renderNode(child, layout)).join('')
+  return `${openTag}${inner}</${tag}>`
+}
+
+function renderHead(metadata?: SSRMetadata): string {
+  if (metadata === undefined) return ''
+
+  let html = ''
+
+  if (metadata.title !== undefined) {
+    html += `<title>${escapeHtml(metadata.title)}</title>`
+  }
+
+  if (metadata.description !== undefined) {
+    html += `<meta name="description" content="${escapeHtml(metadata.description)}">`
+  }
+
+  if (metadata.og !== undefined) {
+    const keys = Object.keys(metadata.og).sort()
+    for (const key of keys) {
+      html += `<meta property="og:${escapeHtml(key)}" content="${escapeHtml(metadata.og[key]!)}">`
+    }
+  }
+
+  return html
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}

--- a/tests/ssr.test.ts
+++ b/tests/ssr.test.ts
@@ -1,0 +1,137 @@
+import { describe, test, expect } from 'bun:test'
+import { defineComponent, renderToString, createPortal } from '../src/index.js'
+
+describe('SSR: renderToString', () => {
+  test('genera HTML base válido', async () => {
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'main',
+      children: [{ type: 'text' as const, content: 'Hola SSR' }],
+    }))
+
+    const html = await renderToString(App)
+
+    expect(html.startsWith('<!DOCTYPE html>')).toBe(true)
+    expect(html).toContain('<html>')
+    expect(html).toContain('<head>')
+    expect(html).toContain('<body>')
+    expect(html).toContain('<div id="app">')
+    expect(html).toContain('Hola SSR')
+  })
+
+  test('serializa texto y atributos con escape seguro', async () => {
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      attrs: {
+        title: 'x" y\' z <tag> &',
+      },
+      children: [{ type: 'text' as const, content: '<script>alert("x")</script> & "ok"' }],
+    }))
+
+    const html = await renderToString(App)
+
+    expect(html).toContain('title="x&quot; y&#39; z &lt;tag&gt; &amp;"')
+    expect(html).toContain('&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; &quot;ok&quot;')
+    expect(html).not.toContain('<script>alert("x")</script>')
+  })
+
+  test('preserva estructura, attrs y classes, e incluye estilos de layout inline', async () => {
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'section',
+      classes: ['root', 'layout'],
+      attrs: { 'data-role': 'content' },
+      layout: { width: 320, height: 200 },
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'p',
+          classes: ['copy'],
+          attrs: { id: 'lead' },
+          children: [{ type: 'text' as const, content: 'Texto principal' }],
+        },
+      ],
+    }))
+
+    const html = await renderToString(App, { width: 320, height: 200 })
+
+    expect(html).toContain('<section')
+    expect(html).toContain('class="root layout"')
+    expect(html).toContain('data-role="content"')
+    expect(html).toContain('<p')
+    expect(html).toContain('class="copy"')
+    expect(html).toContain('id="lead"')
+    expect(html).toMatch(/style="[^"]*left:0px;top:0px;width:\d+px;height:\d+px;[^"]*"/)
+  })
+
+  test('portal y fragment se serializan inline en v0.2.6', async () => {
+    const fakeTarget = {} as HTMLElement
+
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'fragment' as const,
+          children: [
+            { type: 'element' as const, tag: 'span', children: [{ type: 'text' as const, content: 'Inline A' }] },
+          ],
+        },
+        createPortal(
+          [{ type: 'element' as const, tag: 'em', children: [{ type: 'text' as const, content: 'Portal Inline' }] }],
+          fakeTarget
+        ),
+      ],
+    }))
+
+    const html = await renderToString(App)
+
+    expect(html).toContain('<span')
+    expect(html).toContain('Inline A')
+    expect(html).toContain('<em')
+    expect(html).toContain('Portal Inline')
+  })
+
+  test('inyecta metadata en head', async () => {
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [{ type: 'text' as const, content: 'SEO' }],
+    }))
+
+    const html = await renderToString(App, {
+      metadata: {
+        title: 'Página SSR',
+        description: 'Descripción <segura> & útil',
+        og: {
+          type: 'article',
+          image: 'https://cdn.example.com/hero.png?x=1&y=2',
+        },
+      },
+    })
+
+    expect(html).toContain('<title>Página SSR</title>')
+    expect(html).toContain('<meta name="description" content="Descripción &lt;segura&gt; &amp; útil">')
+    expect(html).toContain('<meta property="og:type" content="article">')
+    expect(html).toContain('<meta property="og:image" content="https://cdn.example.com/hero.png?x=1&amp;y=2">')
+  })
+
+  test('policy router/url: acepta options.url sin tocar window en SSR', async () => {
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [{ type: 'text' as const, content: 'URL-safe SSR' }],
+    }))
+
+    const html = await renderToString(App, { url: '/post/42?tab=info#top' })
+    expect(html).toContain('URL-safe SSR')
+    expect(html).toContain('<div id="app">')
+  })
+})
+
+describe('SSR: export público', () => {
+  test('renderToString está expuesto desde entrypoint público', () => {
+    expect(typeof renderToString).toBe('function')
+  })
+})

--- a/tests/ssr.test.ts
+++ b/tests/ssr.test.ts
@@ -62,7 +62,7 @@ describe('SSR: renderToString', () => {
     expect(html).toContain('<p')
     expect(html).toContain('class="copy"')
     expect(html).toContain('id="lead"')
-    expect(html).toMatch(/style="[^"]*left:0px;top:0px;width:\d+px;height:\d+px;[^"]*"/)
+    expect(html).toMatch(/style="position:absolute;left:0px;top:0px;transform:translate\(\d+px,\d+px\);width:\d+px;height:\d+px;/)
   })
 
   test('portal y fragment se serializan inline en v0.2.6', async () => {


### PR DESCRIPTION
## Summary
Adds a server-side rendering entrypoint that serializes prepared/reflowed component trees into HTML.

## Type of change
- [x] feat — new feature (minor bump)
- [ ] fix — bug fix (patch bump)
- [ ] feat! / BREAKING CHANGE — breaking change (major bump)
- [ ] perf — performance improvement (patch bump)
- [ ] refactor — no behavior change
- [ ] test — tests only
- [ ] docs — documentation only
- [ ] ci — workflow changes
- [ ] chore — maintenance

## Checklist
- [x] Tests added or updated for the changed behavior
- [x] Bun test passes locally (all tests green)
- [x] Bun run typecheck passes locally
- [x] Commit messages follow Conventional Commits format
- [x] Hot path invariant respected: no DOM reads added
- [x] No runtime dependencies added to src/

## Related issues
Closes #16

## Testing notes
- bun run typecheck
- bun test

## Summary by Sourcery

Agregar un punto de entrada de renderizado del lado del servidor que serializa árboles de componentes preparados en cadenas HTML con marcado consciente del diseño y metadatos opcionales.

Nuevas funciones:
- Exponer una API pública `renderToString` que renderiza componentes a una cadena de documento HTML para renderizado del lado del servidor.
- Admitir opciones de renderizado SSR para dimensionado, tipografía, motor de maquetación de texto y contrato de URL inicial.
- Permitir pasar metadatos de SSR (título, descripción, etiquetas Open Graph) para completar la cabecera del documento en la salida SSR.

Pruebas:
- Agregar pruebas que cubran el nuevo punto de entrada SSR `renderToString` y el comportamiento de su salida HTML.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a server-side rendering entrypoint that serializes prepared component trees into HTML strings with layout-aware markup and optional metadata.

New Features:
- Expose a public renderToString API that renders components to an HTML document string for server-side rendering.
- Support SSR rendering options for sizing, typography, text layout engine, and initial URL contract.
- Allow passing SSR metadata (title, description, Open Graph tags) to populate the document head in SSR output.

Tests:
- Add tests covering the new renderToString SSR entrypoint and its HTML output behavior.

</details>