### PR TITLE
feat: Sprint 6 DX v0.2.7 — Developer Experience Capabilities

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,7 @@
       </label>
       <button id="anim-btn" class="btn-toggle active">▶ Animación</button>
       <button id="metrics-btn" class="btn-toggle active">📊 Métricas</button>
+      <a href="/ssr?name=Dev&width=960&root=ssr-root" class="btn-toggle btn-link">🧪 SSR Demo (server)</a>
     </div>
   </header>
 

--- a/demo/server.ts
+++ b/demo/server.ts
@@ -7,6 +7,136 @@ const skipBuild = Bun.argv.includes('--no-build')
 const ROOT_DIR = join(import.meta.dir, '..')
 const DEMO_DIR = import.meta.dir
 
+type SSRModule = typeof import('../dist/index.js')
+let ssrModulePromise: Promise<SSRModule> | null = null
+
+function loadSSRModule(): Promise<SSRModule> {
+  if (ssrModulePromise === null) {
+    ssrModulePromise = import('../dist/index.js') as Promise<SSRModule>
+  }
+  return ssrModulePromise
+}
+
+async function renderSSRPage(url: URL): Promise<Response> {
+  const { defineComponent, renderToString } = await loadSSRModule()
+
+  const route = url.pathname
+  const name = (url.searchParams.get('name') ?? 'Axiom').trim() || 'Axiom'
+  const width = parseWidth(url.searchParams.get('width'))
+  const rootId = sanitizeRootId(url.searchParams.get('root'))
+  const qs = `?name=${encodeURIComponent(name)}&width=${width}&root=${encodeURIComponent(rootId)}`
+
+  const SSRDemoApp = defineComponent(() => ({
+    type: 'element' as const,
+    tag: 'main',
+    classes: ['ssr-shell', 'card'],
+    attrs: {
+      style: 'margin:24px auto;max-width:960px;background:#12121f;border:1px solid #2a2a4a;border-radius:14px;color:#e2e2f0;font-family:system-ui,sans-serif;box-shadow:0 16px 40px rgba(0,0,0,.35);',
+    },
+    layout: { flexDirection: 'column', gap: 12, padding: 20 },
+    children: [
+      {
+        type: 'element' as const,
+        tag: 'h1',
+        attrs: { style: 'font-size:28px;font-weight:800;color:#a78bfa;' },
+        children: [{ type: 'text' as const, content: 'SSR Demo — Axiom renderToString()' }],
+      },
+      {
+        type: 'element' as const,
+        tag: 'p',
+        attrs: { style: 'color:#b2b2d0;' },
+        children: [{ type: 'text' as const, content: `Hola ${name}, esta página fue renderizada en servidor con renderToString().` }],
+      },
+      {
+        type: 'element' as const,
+        tag: 'code',
+        attrs: {
+          style: 'display:block;padding:10px 12px;background:#0a0a14;border:1px solid #2a2a4a;border-radius:8px;color:#5eead4;',
+        },
+        children: [{ type: 'text' as const, content: `GET ${route}${qs}` }],
+      },
+      {
+        type: 'element' as const,
+        tag: 'div',
+        layout: { flexDirection: 'column', gap: 6 },
+        children: [
+          {
+            type: 'element' as const,
+            tag: 'p',
+            attrs: { style: 'color:#9ca3af;font-size:14px;' },
+            children: [{ type: 'text' as const, content: `Ancho SSR: ${width}px · rootId: ${rootId}` }],
+          },
+          {
+            type: 'element' as const,
+            tag: 'p',
+            attrs: { style: 'color:#9ca3af;font-size:14px;' },
+            children: [{ type: 'text' as const, content: 'Tip: modifica query params para probar SSR.' }],
+          },
+          {
+            type: 'element' as const,
+            tag: 'p',
+            attrs: { style: 'color:#e2e2f0;' },
+            children: [
+              { type: 'text' as const, content: 'Ejemplo: ' },
+              {
+                type: 'element' as const,
+                tag: 'a',
+                attrs: {
+                  href: '/ssr?name=Dev&width=720&root=ssr-root',
+                  style: 'color:#a78bfa;text-decoration:none;border-bottom:1px dashed #a78bfa;',
+                },
+                children: [{ type: 'text' as const, content: '/ssr?name=Dev&width=720&root=ssr-root' }],
+              },
+            ],
+          },
+        ],
+      },
+      { type: 'element' as const, tag: 'hr', attrs: { style: 'border:0;border-top:1px solid #2a2a4a;' } },
+      {
+        type: 'element' as const,
+        tag: 'a',
+        attrs: {
+          href: '/',
+          style: 'color:#5eead4;text-decoration:none;font-weight:700;',
+        },
+        children: [{ type: 'text' as const, content: '← Volver al demo interactivo' }],
+      },
+    ],
+  }))
+
+  const html = await renderToString(SSRDemoApp, {
+    width,
+    height: 720,
+    url: `${url.pathname}${url.search}`,
+    rootId,
+    metadata: {
+      title: 'Axiom SSR Demo',
+      description: 'Demo SSR con renderToString, rootId configurable y layout consistente con cliente.',
+      og: {
+        type: 'website',
+      },
+    },
+  })
+
+  return new Response(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+    },
+  })
+}
+
+function parseWidth(raw: string | null): number {
+  const parsed = Number.parseInt(raw ?? '960', 10)
+  if (!Number.isFinite(parsed) || Number.isNaN(parsed)) return 960
+  return Math.max(320, Math.min(1600, parsed))
+}
+
+function sanitizeRootId(raw: string | null): string {
+  const value = (raw ?? 'ssr-root').trim()
+  if (value.length === 0) return 'ssr-root'
+  return /^[A-Za-z_][\w-]*$/.test(value) ? value : 'ssr-root'
+}
+
 async function doBuild(): Promise<boolean> {
   console.log('📦 Building framework (dist)...')
 
@@ -78,8 +208,13 @@ if (isWatch) {
 
 serve({
   port: 3000,
-  fetch(req) {
+  async fetch(req) {
     const url = new URL(req.url)
+
+    if (url.pathname === '/ssr') {
+      return renderSSRPage(url)
+    }
+
     let path = url.pathname === '/' ? '/index.html' : url.pathname
 
     const filePath = join(DEMO_DIR, path)


### PR DESCRIPTION
Closes #19

## Type
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling

## Summary

Implement 4 developer experience (DX) capabilities for Axiom v0.2.7:

- **Profiling API** — ProfileEvent emission with ordered phases (prepare/reflow/commit/total)
- **Dev Hook** — window.__AXIOM__ readonly/frozen dev-only metadata
- **Error Context** — displayName + route breadcrumb + phase tracing in error callbacks
- **Hot Reload Recovery** — Identity-based definition change detection with partial state preservation

## Changes

| File | Changes |
|------|---------|
| src/types.ts | +ProfilePhase, ProfileEvent, AxiomDevHook types; +displayName to ComponentDefinition |
| src/app.ts | +enableProfiling(), enableHotReloadRecovery(), onError callback; hot reload logic |
| src/component.ts | +displayName overload, NODE_DEBUG_META tracking, withComponentRoute, resolveComponentDisplayName |
| src/prepare.ts | +inheritedDebug parameter propagation, getDebugDisplayName, getDebugRoute exports |
| src/commit.ts | +assertValidTagName validation, getElementsByTagName robustness |
| src/index.ts | +AxiomDevHook, ProfileEvent, AppErrorContext exports |
| tests/app.test.ts | +35 tests: profiling order, dev hook guarding, error contexts, hot reload scenarios |
| tests/component.test.ts | +displayName tests |

## Validation

- Tests: ✅ 35 pass, 0 fail
- Typecheck: ✅ Green
- SDD Verify: ✅ PASS (100% criteria)
- Backward compatible: ✅ No breaking changes
- API additions: Opt-in (enableProfiling, enableHotReloadRecovery, onError callback)

## Summary by Sourcery

Agregar un endpoint de demostración de renderizado del lado del servidor y enlazarlo desde la interfaz de demostración.

Nuevas funcionalidades:
- Introducir una página de demostración SSR renderizada mediante `renderToString` con parámetros de consulta configurables para `name`, `width` y `rootId`.

Mejoras:
- Reutilizar un módulo SSR cargado de forma diferida en el servidor de demostración para evitar importaciones repetidas.
- Añadir funciones auxiliares sólidas para el análisis y la sanitización de `width` de SSR y del ID del elemento raíz en el servidor de demostración.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a server-side rendering demo endpoint and link it from the demo UI.

New Features:
- Introduce an SSR demo page rendered via renderToString with configurable query parameters for name, width, and rootId.

Enhancements:
- Reuse a lazily loaded SSR module in the demo server to avoid repeated imports.
- Add robust parsing and sanitization helpers for SSR width and root element ID in the demo server.

</details>