### PR TITLE
fix(diff): detectar cambios de clases CSS en fast path

### DIFF
--- a/docs/V1-0-0-EVIDENCE-LOG.md
+++ b/docs/V1-0-0-EVIDENCE-LOG.md
@@ -39,7 +39,7 @@ Plantilla:
 ### 2026-04-16 — Fix P0: fast path no detecta cambios de clases CSS en re-render
 
 - Issue: #43
-- PR: TBD (rama `fix/issue-43-class-diff`)
+- PR: #44 (rama `fix/issue-43-class-diff`)
 - Verificación:
   - [x] `bun run typecheck` — limpio (0 errores)
   - [x] `bun test` — 417 pass / 2 skip / 0 fail

--- a/docs/V1-0-0-EVIDENCE-LOG.md
+++ b/docs/V1-0-0-EVIDENCE-LOG.md
@@ -36,6 +36,22 @@ Plantilla:
 
 ## Entradas
 
+### 2026-04-16 — Fix P0: fast path no detecta cambios de clases CSS en re-render
+
+- Issue: #43
+- PR: TBD (rama `fix/issue-43-class-diff`)
+- Verificación:
+  - [x] `bun run typecheck` — limpio (0 errores)
+  - [x] `bun test` — 417 pass / 2 skip / 0 fail
+- Evidencia:
+  - Root cause: `fullDiff` fast path y `fullTreeDiff` nunca comparaban el array `classes`; `applyOps` no tenía handler para `newClasses`; el fast path emitía coords de layout para cambios de metadata, rompiendo portal CSS-managed children.
+  - Fix: helper `classesEqual()`, campo `newClasses?: string[]` en `DOMOperation`, separación de `layoutChangedSet` vs `allChangedSet` en fast path (coords solo cuando layout cambió), detección de `classesChanged` en `fullTreeDiff`, handler `el.className` en `applyOps`.
+  - Nuevos tests: `same-shape fast path detecta cambio de clases y emite newClasses sin coords de layout`, `fullTreeDiff detecta cambio de clases`, `applyOps aplica newClasses`, `applyOps con newClasses vacío limpia className`.
+  - archivos: `src/render/diff.ts`, `src/render/commit.ts`, `tests/diff.test.ts`, `tests/commit.test.ts`
+- Resultado: PASS
+- Notas/Riesgos:
+  - Bug secundario (coords emitidas para nodos de portal CSS-managed en cambios de metadata) corregido como parte del mismo fix — separación de `layoutChangedSet`.
+
 ### 2026-04-15 — Snapshot final local pre-PR (release readiness)
 
 - Issue: #30 (épica 1.0.0)

--- a/src/render/commit.ts
+++ b/src/render/commit.ts
@@ -338,6 +338,10 @@ export function applyOps(
           applyManagedStyleToElement(el, op.newStyle)
         }
       }
+
+      if ('newClasses' in op && el instanceof HTMLElement) {
+        el.className = (op.newClasses ?? []).join(' ')
+      }
     }
 
     if (op.type === 'move') {

--- a/src/render/diff.ts
+++ b/src/render/diff.ts
@@ -48,6 +48,7 @@ export interface DOMOperation {
   newTextContent?: string
   newOn?: Record<string, EventListener>
   newStyle?: import('../features/style.js').SafeStyleProps
+  newClasses?: string[]
 }
 
 // ============================================================
@@ -83,6 +84,20 @@ function buildPortalMap(prepared: PreparedComponent): Map<number, PortalMapEntry
   }
   walk(prepared)
   return map
+}
+
+// ============================================================
+// Class Equality Helper
+// ============================================================
+
+function classesEqual(a: string[] | undefined, b: string[] | undefined): boolean {
+  if (a === b) return true
+  if (a === undefined || b === undefined) return false
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
 }
 
 // ============================================================
@@ -155,16 +170,18 @@ export function fullDiff(
     const prevByIndex = buildIndexMap(prevPrepared)
     const newByIndex = buildIndexMap(newPrepared)
 
-    const changed = fastDiff(prevLayout, newLayout)
-    const changedSet = new Set<number>(changed)
+    const layoutChangedIndices = fastDiff(prevLayout, newLayout)
+    const layoutChangedSet = new Set<number>(layoutChangedIndices)
+    const allChanged = [...layoutChangedIndices]
+    const allChangedSet = new Set<number>(layoutChangedIndices)
     const markChanged = (idx: number): void => {
-      if (!changedSet.has(idx)) {
-        changedSet.add(idx)
-        changed.push(idx)
+      if (!allChangedSet.has(idx)) {
+        allChangedSet.add(idx)
+        allChanged.push(idx)
       }
     }
 
-    // Also check for text content changes
+    // Also check for text content, on, style and class changes
     forEachNode(newPrepared, (node) => {
       const idx = getNodeIndex(node)
       if (getNodeType(node) === 'text') {
@@ -186,17 +203,28 @@ export function fullDiff(
         if (newStyle !== oldStyle) {
           markChanged(idx)
         }
+        const newClasses = getClasses(node)
+        const oldClasses = oldNode ? getClasses(oldNode) : undefined
+        if (!classesEqual(newClasses, oldClasses)) {
+          markChanged(idx)
+        }
       }
     })
 
-    for (const idx of changed) {
+    for (const idx of allChanged) {
       const op: DOMOperation = {
         type: 'update',
         index: idx,
-        x: newLayout.x[idx],
-        y: newLayout.y[idx],
-        width: newLayout.width[idx],
-        height: newLayout.height[idx],
+      }
+
+      // Emit layout coords ONLY when layout actually changed.
+      // Portal CSS-managed children must NOT receive position coords for metadata-only changes
+      // (class/text/style/on) — applyFrameworkLayout would stack them all at (0,0).
+      if (layoutChangedSet.has(idx)) {
+        op.x = newLayout.x[idx]
+        op.y = newLayout.y[idx]
+        op.width = newLayout.width[idx]
+        op.height = newLayout.height[idx]
       }
 
       // Check text content changes
@@ -218,6 +246,11 @@ export function fullDiff(
         const oldStyle = oldNode ? getStyle(oldNode) : undefined
         if (newStyle !== oldStyle) {
           op.newStyle = newStyle
+        }
+        const newClasses = getClasses(newNode)
+        const oldClasses = oldNode ? getClasses(oldNode) : undefined
+        if (!classesEqual(newClasses, oldClasses)) {
+          op.newClasses = newClasses
         }
       }
 
@@ -331,6 +364,8 @@ function fullTreeDiff(
       let newOn: Record<string, EventListener> | undefined
       let styleChanged = false
       let newStyle: import('../features/style.js').SafeStyleProps | undefined
+      let classesChanged = false
+      let newClassesVal: string[] | undefined
 
       if (nodeType === 'text') {
         const oldNode = prevByIndex.get(idx)
@@ -354,9 +389,15 @@ function fullTreeDiff(
           styleChanged = true
           newStyle = currentStyle
         }
+        const oldClasses = oldNode ? getClasses(oldNode) : undefined
+        const currentClasses = getClasses(node)
+        if (!classesEqual(currentClasses, oldClasses)) {
+          classesChanged = true
+          newClassesVal = currentClasses
+        }
       }
 
-      if (layoutChanged || textChanged || onChanged || styleChanged) {
+      if (layoutChanged || textChanged || onChanged || styleChanged || classesChanged) {
         const op: DOMOperation = {
           type: 'update',
           index: idx,
@@ -375,6 +416,9 @@ function fullTreeDiff(
         }
         if (styleChanged) {
           op.newStyle = newStyle
+        }
+        if (classesChanged) {
+          op.newClasses = newClassesVal
         }
         ops.push(op)
       }

--- a/src/render/diff.ts
+++ b/src/render/diff.ts
@@ -92,10 +92,11 @@ function buildPortalMap(prepared: PreparedComponent): Map<number, PortalMapEntry
 
 function classesEqual(a: string[] | undefined, b: string[] | undefined): boolean {
   if (a === b) return true
-  if (a === undefined || b === undefined) return false
-  if (a.length !== b.length) return false
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) return false
+  const arrA = a ?? []
+  const arrB = b ?? []
+  if (arrA.length !== arrB.length) return false
+  for (let i = 0; i < arrA.length; i++) {
+    if (arrA[i] !== arrB[i]) return false
   }
   return true
 }
@@ -211,6 +212,8 @@ export function fullDiff(
       }
     })
 
+    allChanged.sort((a, b) => a - b)
+
     for (const idx of allChanged) {
       const op: DOMOperation = {
         type: 'update',
@@ -325,6 +328,46 @@ function fullTreeDiff(
             width: newLayout.width[idx],
             height: newLayout.height[idx],
           })
+
+          const oldNode = prevByIndex.get(oldIdx)
+          if (oldNode !== undefined) {
+            const metadataUpdate: DOMOperation = { type: 'update', index: idx }
+            let hasMetadataUpdate = false
+
+            if (nodeType === 'text') {
+              const oldText = getTextContent(oldNode)
+              const newText = getTextContent(node)
+              if (newText !== oldText) {
+                metadataUpdate.newTextContent = newText
+                hasMetadataUpdate = true
+              }
+            } else if (nodeType === 'element') {
+              const oldOn = getOn(oldNode)
+              const currentOn = getOn(node)
+              if (currentOn !== oldOn) {
+                metadataUpdate.newOn = currentOn
+                hasMetadataUpdate = true
+              }
+
+              const oldStyle = getStyle(oldNode)
+              const currentStyle = getStyle(node)
+              if (currentStyle !== oldStyle) {
+                metadataUpdate.newStyle = currentStyle
+                hasMetadataUpdate = true
+              }
+
+              const oldClasses = getClasses(oldNode)
+              const currentClasses = getClasses(node)
+              if (!classesEqual(currentClasses, oldClasses)) {
+                metadataUpdate.newClasses = currentClasses
+                hasMetadataUpdate = true
+              }
+            }
+
+            if (hasMetadataUpdate) {
+              ops.push(metadataUpdate)
+            }
+          }
           return
         }
       }

--- a/tests/commit.test.ts
+++ b/tests/commit.test.ts
@@ -120,6 +120,43 @@ describe('applyOps', () => {
     expect(Array.isArray((child as any).__axiomManagedStyleKeys)).toBe(true)
   })
 
+  test('update con newClasses aplica el className correcto al elemento', () => {
+    const root = document.createElement('div')
+    const child = document.createElement('article')
+    child.className = 'card'
+    root.appendChild(child)
+
+    const domNodes: (HTMLElement | Text | null)[] = [child]
+
+    const ops: DOMOperation[] = [
+      { type: 'update', index: 0, newClasses: ['card', 'active'] },
+    ]
+
+    applyOps(ops, root, domNodes)
+
+    expect(child.className).toBe('card active')
+    // Sin coords en el op — no debe haberse aplicado layout
+    expect(child.style.transform).toBe('')
+    expect(child.style.position).toBe('')
+  })
+
+  test('update con newClasses vacío limpia el className', () => {
+    const root = document.createElement('div')
+    const child = document.createElement('article')
+    child.className = 'card active'
+    root.appendChild(child)
+
+    const domNodes: (HTMLElement | Text | null)[] = [child]
+
+    const ops: DOMOperation[] = [
+      { type: 'update', index: 0, newClasses: [] },
+    ]
+
+    applyOps(ops, root, domNodes)
+
+    expect(child.className).toBe('')
+  })
+
   test('operations are applied in order: removes → updates → inserts', () => {
     const root = document.createElement('div')
     const oldChild = document.createElement('span')

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -475,6 +475,11 @@ describe('fullDiff', () => {
     if (classUpdate && classUpdate.type === 'update') {
       expect('newClasses' in classUpdate).toBe(true)
       expect(classUpdate.newClasses).toEqual(['card', 'active'])
+      // En shape-change, si el layout de ese índice no cambia, no debe emitir coords.
+      expect(classUpdate.x).toBeUndefined()
+      expect(classUpdate.y).toBeUndefined()
+      expect(classUpdate.width).toBeUndefined()
+      expect(classUpdate.height).toBeUndefined()
     }
   })
 })

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -373,6 +373,110 @@ describe('fullDiff', () => {
       expect(styleUpdate.newStyle).toBeUndefined()
     }
   })
+
+  test('same-shape fast path detecta cambio de clases y emite newClasses sin coords de layout', () => {
+    const compA = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          classes: ['card'],
+          children: [{ type: 'text' as const, content: 'Item' }],
+        },
+      ],
+    }))
+
+    const compB = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          classes: ['card', 'active'],
+          children: [{ type: 'text' as const, content: 'Item' }],
+        },
+      ],
+    }))
+
+    const prevPrepared = prepare(compA, undefined, { textEngine: fakeTextEngine })
+    const newPrepared = prepare(compB, undefined, { textEngine: fakeTextEngine })
+    const prevLayout = createLayoutResult(prevPrepared)
+    const newLayout = createLayoutResult(newPrepared)
+    // Layout idéntico — no hubo cambio posicional
+
+    const domNodes: (HTMLElement | Text | null)[] = [
+      document.createElement('div'),
+      document.createElement('article'),
+      document.createTextNode('Item'),
+    ]
+
+    const ops = fullDiff(prevPrepared, prevLayout, newPrepared, newLayout, domNodes)
+    const classUpdate = ops.find((op) => op.type === 'update' && op.index === 1)
+    expect(classUpdate).toBeDefined()
+    expect(classUpdate && 'newClasses' in classUpdate).toBe(true)
+    if (classUpdate && classUpdate.type === 'update') {
+      expect(classUpdate.newClasses).toEqual(['card', 'active'])
+      // Coords NO deben estar presentes — el layout no cambió
+      expect(classUpdate.x).toBeUndefined()
+      expect(classUpdate.y).toBeUndefined()
+      expect(classUpdate.width).toBeUndefined()
+      expect(classUpdate.height).toBeUndefined()
+    }
+  })
+
+  test('fullTreeDiff (shape-change) detecta cambio de clases y emite newClasses sin coords si layout no cambió', () => {
+    // shape-change: nodeCount cambia de 3 a 4
+    const compA = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          classes: ['card'],
+          children: [{ type: 'text' as const, content: 'Item' }],
+        },
+      ],
+    }))
+
+    const compB = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          classes: ['card', 'active'],
+          children: [
+            { type: 'text' as const, content: 'Item' },
+            { type: 'text' as const, content: ' extra' },
+          ],
+        },
+      ],
+    }))
+
+    const prevPrepared = prepare(compA, undefined, { textEngine: fakeTextEngine })
+    const newPrepared = prepare(compB, undefined, { textEngine: fakeTextEngine })
+    const prevLayout = createLayoutResult(prevPrepared)
+    const newLayout = createLayoutResult(newPrepared)
+
+    const domNodes: (HTMLElement | Text | null)[] = [
+      document.createElement('div'),
+      document.createElement('article'),
+      document.createTextNode('Item'),
+    ]
+
+    const ops = fullDiff(prevPrepared, prevLayout, newPrepared, newLayout, domNodes)
+    const classUpdate = ops.find((op) => op.type === 'update' && op.index === 1)
+    // El índice 1 (article) está en ambas versiones — debe detectar cambio de clases
+    if (classUpdate && classUpdate.type === 'update') {
+      expect('newClasses' in classUpdate).toBe(true)
+      expect(classUpdate.newClasses).toEqual(['card', 'active'])
+    }
+  })
 })
 
 // ============================================================

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -427,6 +427,109 @@ describe('fullDiff', () => {
     }
   })
 
+  test('same-shape no emite update cuando classes es undefined vs []', () => {
+    const compA = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          children: [{ type: 'text' as const, content: 'Item' }],
+        },
+      ],
+    }))
+
+    const compB = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          classes: [],
+          children: [{ type: 'text' as const, content: 'Item' }],
+        },
+      ],
+    }))
+
+    const prevPrepared = prepare(compA, undefined, { textEngine: fakeTextEngine })
+    const newPrepared = prepare(compB, undefined, { textEngine: fakeTextEngine })
+    const prevLayout = createLayoutResult(prevPrepared)
+    const newLayout = createLayoutResult(newPrepared)
+
+    const domNodes: (HTMLElement | Text | null)[] = [
+      document.createElement('div'),
+      document.createElement('article'),
+      document.createTextNode('Item'),
+    ]
+
+    const ops = fullDiff(prevPrepared, prevLayout, newPrepared, newLayout, domNodes)
+    const classUpdate = ops.find((op) => op.type === 'update' && op.index === 1)
+    expect(classUpdate).toBeUndefined()
+  })
+
+  test('same-shape mantiene ordering determinista por índice en updates', () => {
+    const compA = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          classes: ['card'],
+          children: [{ type: 'text' as const, content: 'A' }],
+        },
+        {
+          type: 'element' as const,
+          tag: 'section',
+          children: [{ type: 'text' as const, content: 'B' }],
+        },
+      ],
+    }))
+
+    const compB = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'article',
+          classes: ['card', 'active'],
+          children: [{ type: 'text' as const, content: 'A' }],
+        },
+        {
+          type: 'element' as const,
+          tag: 'section',
+          children: [{ type: 'text' as const, content: 'B' }],
+        },
+      ],
+    }))
+
+    const prevPrepared = prepare(compA, undefined, { textEngine: fakeTextEngine })
+    const newPrepared = prepare(compB, undefined, { textEngine: fakeTextEngine })
+    const prevLayout = createLayoutResult(prevPrepared)
+    const newLayout = createLayoutResult(newPrepared)
+
+    // Fuerza cambio de layout en índice mayor (section idx=3)
+    newLayout.x[3] = 50
+
+    const domNodes: (HTMLElement | Text | null)[] = [
+      document.createElement('div'),
+      document.createElement('article'),
+      document.createTextNode('A'),
+      document.createElement('section'),
+      document.createTextNode('B'),
+    ]
+
+    const ops = fullDiff(prevPrepared, prevLayout, newPrepared, newLayout, domNodes)
+    const updateIndices = ops
+      .filter((op) => op.type === 'update')
+      .map((op) => op.index)
+
+    expect(updateIndices).toEqual([1, 3])
+  })
+
   test('fullTreeDiff (shape-change) detecta cambio de clases y emite newClasses sin coords si layout no cambió', () => {
     // shape-change: nodeCount cambia de 3 a 4
     const compA = defineComponent(() => ({
@@ -480,6 +583,87 @@ describe('fullDiff', () => {
       expect(classUpdate.y).toBeUndefined()
       expect(classUpdate.width).toBeUndefined()
       expect(classUpdate.height).toBeUndefined()
+    }
+  })
+
+  test('fullTreeDiff emite update de metadata para nodo movido por key', () => {
+    // shape-change + reorder por key: fuerza fullTreeDiff (no fast path)
+    const compA = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'span',
+          key: 'a',
+          classes: ['item', 'a'],
+          children: [{ type: 'text' as const, content: 'A' }],
+        },
+        {
+          type: 'element' as const,
+          tag: 'span',
+          key: 'b',
+          classes: ['item'],
+          children: [{ type: 'text' as const, content: 'B' }],
+        },
+      ],
+    }))
+
+    const compB = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'i',
+          children: [{ type: 'text' as const, content: 'N1' }],
+        },
+        {
+          type: 'element' as const,
+          tag: 'i',
+          children: [{ type: 'text' as const, content: 'N2' }],
+        },
+        {
+          type: 'element' as const,
+          tag: 'span',
+          key: 'b',
+          classes: ['item', 'active'],
+          children: [{ type: 'text' as const, content: 'B' }],
+        },
+        {
+          type: 'element' as const,
+          tag: 'span',
+          key: 'a',
+          classes: ['item', 'a'],
+          children: [{ type: 'text' as const, content: 'A' }],
+        },
+        { type: 'text' as const, content: 'tail' },
+      ],
+    }))
+
+    const prevPrepared = prepare(compA, undefined, { textEngine: fakeTextEngine })
+    const newPrepared = prepare(compB, undefined, { textEngine: fakeTextEngine })
+    const prevLayout = createLayoutResult(prevPrepared)
+    const newLayout = createLayoutResult(newPrepared)
+
+    const domNodes: (HTMLElement | Text | null)[] = [
+      document.createElement('div'),
+      document.createElement('span'), // key a
+      document.createTextNode('A'),
+      document.createElement('span'), // key b
+      document.createTextNode('B'),
+    ]
+
+    const ops = fullDiff(prevPrepared, prevLayout, newPrepared, newLayout, domNodes)
+
+    const moveB = ops.find((op) => op.type === 'move' && op.index === 5)
+    expect(moveB).toBeDefined()
+
+    // Además del move, debe existir update para metadata del mismo índice.
+    const updateB = ops.find((op) => op.type === 'update' && op.index === 5)
+    expect(updateB).toBeDefined()
+    if (updateB && updateB.type === 'update') {
+      expect(updateB.newClasses).toEqual(['item', 'active'])
     }
   })
 })


### PR DESCRIPTION
Closes #43

## Resumen
- Detecta cambios de classes en ullDiff y ullTreeDiff.
- Evita emitir coordenadas cuando solo cambia metadata (clases/eventos/estilos).
- Aplica 
ewClasses en commit para reflejar cambios en className.

## Validación
- Tests de diff y commit cubren cambio de clases y no reposicionamiento accidental en (0,0).

## Summary by Sourcery

Detectar cambios en clases CSS en operaciones de diff sin emitir coordenadas de layout para actualizaciones solo de metadatos y asegurar que el commit aplique correctamente las clases actualizadas a los elementos del DOM.

Bug Fixes:
- Detectar cambios en clases CSS tanto en el fast-path `fullDiff` como en `fullTreeDiff` para que las actualizaciones de `className` no se pasen por alto.
- Evitar emitir coordenadas de layout para nodos cuyo layout no cambió, evitando el reposicionamiento incorrecto de hijos gestionados por CSS cuando solo cambian los metadatos.

Documentation:
- Actualizar el registro de evidencias de la versión 1.0.0 con detalles del bug en el diff de clases, su causa raíz, las correcciones y los pasos de validación.

Tests:
- Agregar pruebas de diff que cubran cambios de clases en escenarios de misma forma y cambio de forma, comprobando que `newClasses` se emite sin coordenadas de layout cuando el layout no cambia.
- Agregar pruebas de commit que verifiquen que `applyOps` actualiza `element.className` a partir de `newClasses` y lo limpia cuando `newClasses` está vacío.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Detect CSS class changes in diff operations without emitting layout coordinates for metadata-only updates and ensure commit applies updated classes to DOM elements correctly.

Bug Fixes:
- Detect CSS class changes in both fast-path fullDiff and fullTreeDiff so className updates are not missed.
- Avoid emitting layout coordinates for nodes whose layout did not change, preventing incorrect repositioning of CSS-managed children when only metadata changes.

Documentation:
- Update the 1.0.0 evidence log with details of the class-diff bug, its root cause, fixes, and validation steps.

Tests:
- Add diff tests covering class changes in same-shape and shape-change scenarios, asserting newClasses is emitted without layout coordinates when layout is unchanged.
- Add commit tests verifying applyOps updates element className from newClasses and clears it when newClasses is empty.

</details>