### PR TITLE
docs(release): realign v1.0.0 issue traceability for #35 and #38

### DIFF
--- a/docs/V1-0-0-EVIDENCE-LOG.md
+++ b/docs/V1-0-0-EVIDENCE-LOG.md
@@ -71,7 +71,7 @@ Plantilla:
 
 ### 2026-04-15 — Implementación P1: Optimización incremental de diff (index lookup)
 
-- Issue: #40
+- Issue: #38
 - PR: TBD (rama local `feat/v1-0-0-kickoff`)
 - Verificación:
   - [x] `bun test tests/diff.test.ts`
@@ -85,10 +85,11 @@ Plantilla:
 - Resultado: PASS
 - Notas/Riesgos:
   - Umbral de benchmark puede variar por runner/entorno; se mantiene como smoke gate para detectar regresiones gruesas.
+  - Nota de trazabilidad: commits históricos como `3a3b7fa` referenciaron `#40`, pero el issue canónico en GitHub para esta optimización es `#38`.
 
-### 2026-04-15 — Implementación P1: Hydration attrs hardening XSS residual
+### 2026-04-15 — Implementación P1: Hardening XSS residual + alineación docs/código
 
-- Issue: #39
+- Issue: #40
 - PR: TBD (rama local `feat/v1-0-0-kickoff`)
 - Verificación:
   - [x] `bun test tests/commit.test.ts`
@@ -97,14 +98,14 @@ Plantilla:
 - Evidencia:
   - tests: `commitHydrate: security hardening` (remove `on*`, neutralize `javascript:` a `#blocked`, preservación de attrs seguros) y `SSR: attrs security policy`
   - archivos: `src/render/commit.ts`, `tests/commit.test.ts`, `tests/ssr.test.ts`, `SECURITY.md`, `docs/V1-0-0-EVIDENCE-LOG.md`, `docs/V1-0-0-PLAN-TRAZABILIDAD.md`
-  - comportamiento validado: hidratación sanea attrs peligrosos preexistentes del DOM reutilizado y mantiene coherencia de política con SSR.
+  - comportamiento validado: hidratación sanea attrs peligrosos preexistentes del DOM reutilizado y alinea la política documentada de seguridad con el comportamiento real de SSR/hidratación.
 - Resultado: PASS
 - Notas/Riesgos:
   - Endurecimiento deliberado sobre DOM inseguro preexistente; no se introduce reconciliación completa de attrs benignos en hidratación.
 
 ### 2026-04-15 — Implementación P1: Coverage gate en CI
 
-- Issue: #38
+- Issue: #36
 - PR: TBD (rama local `feat/v1-0-0-kickoff`)
 - Verificación:
   - [x] `bun run test:coverage`
@@ -137,7 +138,7 @@ Plantilla:
 
 ### 2026-04-15 — Implementación P1: Hardening attrs/event attrs
 
-- Issue: #36
+- Issue: #39
 - PR: TBD (rama local `feat/v1-0-0-kickoff`)
 - Verificación:
   - [x] `bun test tests/edge-cases.test.ts`
@@ -167,6 +168,22 @@ Plantilla:
 - Resultado: PASS
 - Notas/Riesgos:
   - Política kickoff: export público no etiquetado se considera `stable` en v1.0.0; en fase posterior conviene migrar a tags explícitos por export.
+
+### 2026-04-15 — Implementación P0: SECURITY threat model real (CSR + SSR)
+
+- Issue: #35
+- PR: #41
+- Verificación:
+  - [x] Revisión de `SECURITY.md`
+  - [x] Coherencia de alcance CSR + SSR
+  - [x] Responsabilidades del consumidor documentadas
+- Evidencia:
+  - archivos: `SECURITY.md`
+  - comportamiento validado: el threat model documenta explícitamente CSR y SSR, delimita scope/out-of-scope y aclara responsabilidades sobre sanitización de input, attrs, URLs y riesgos de plugins.
+  - commit relacionado: `3df31b8` (`docs(security): update threat model for v1.0.0 (CSR+SSR, plugins, API stability)`)
+- Resultado: PASS
+- Notas/Riesgos:
+  - La issue quedó abierta por falta de autocierre en PR/commit, no por ausencia de implementación técnica.
 
 ### 2026-04-15 — Implementación P0: Plugin lifecycle runtime
 

--- a/docs/V1-0-0-PLAN-TRAZABILIDAD.md
+++ b/docs/V1-0-0-PLAN-TRAZABILIDAD.md
@@ -76,11 +76,11 @@ Este plan convierte la auditoría técnica en ejecución concreta con criterios 
 | P0 | Aislamiento SSR (`prepare`) | Reliability/concurrency | Done (branch) (#31) |
 | P0 | SECURITY.md threat model | Security governance | Done (branch) (#35) |
 | P0 | API stability contract | SemVer/compatibilidad | Done (branch) (#34) |
-| P1 | Hardening attrs/event attrs | Security hardening | Done (branch) (#36) |
+| P1 | Hardening attrs/event attrs | Security hardening | Done (branch) (#39) |
 | P1 | Scheduler API no-op | API coherence | Done (branch) (#37) |
-| P1 | Coverage gate en CI | Release quality gate | Done (branch) (#38) |
-| P1 | Hardening XSS residual + alineación docs/código | Security/DX trust | Done (branch) (#39) |
-| P1 | Diff performance index lookup | Performance/scalability | Done (branch) (#40) |
+| P1 | Coverage gate en CI | Release quality gate | Done (branch) (#36) |
+| P1 | Hardening XSS residual + alineación docs/código | Security/DX trust | Done (branch) (#40) |
+| P1 | Diff performance index lookup | Performance/scalability | Done (branch) (#38) |
 
 ---
 
@@ -108,11 +108,11 @@ El release `1.0.0` solo puede aprobarse si:
 | P0 Aislamiento SSR prepare | #31 | TBD | `tests/prepare.test.ts` + `tests/portal.test.ts` + `tests/router.test.ts` + `docs/V1-0-0-EVIDENCE-LOG.md` | Done (branch) |
 | P0 SECURITY threat model | #35 | TBD | `SECURITY.md` + `docs/V1-0-0-EVIDENCE-LOG.md` | Done (branch) |
 | P0 API stability contract | #34 | TBD | `scripts/validate-api-stability.ts` + `docs/STABILITY.md` + `bun run validate:api` | Done (branch) |
-| P1 Hardening attrs/event attrs | #36 | TBD | `tests/edge-cases.test.ts` + suite coverage + `SECURITY.md` | Done (branch) |
+| P1 Hardening attrs/event attrs | #39 | TBD | `tests/edge-cases.test.ts` + suite coverage + `SECURITY.md` | Done (branch) |
 | P1 Scheduler API no-op | #37 | TBD | `tests/scheduler.test.ts` + `tests/app.test.ts` | Done (branch) |
-| P1 Coverage gate en CI | #38 | TBD | `.github/workflows/ci.yml` + `scripts/validate-coverage.ts` + `bun run test:coverage` | Done (branch) |
-| P1 Hardening XSS residual + alineación docs/código | #39 | TBD | `tests/commit.test.ts` + `tests/ssr.test.ts` + `SECURITY.md` + `docs/V1-0-0-EVIDENCE-LOG.md` | Done (branch) |
-| P1 Diff performance | #40 | TBD | `tests/diff.test.ts` + `tests/integration.test.ts` + `tests/benchmark.test.ts` | Done (branch) |
+| P1 Coverage gate en CI | #36 | TBD | `.github/workflows/ci.yml` + `scripts/validate-coverage.ts` + `bun run test:coverage` | Done (branch) |
+| P1 Hardening XSS residual + alineación docs/código | #40 | TBD | `tests/commit.test.ts` + `tests/ssr.test.ts` + `SECURITY.md` + `docs/V1-0-0-EVIDENCE-LOG.md` | Done (branch) |
+| P1 Diff performance | #38 | TBD | `tests/diff.test.ts` + `tests/integration.test.ts` + `tests/benchmark.test.ts` | Done (branch) |
 
 ---
 
@@ -126,11 +126,11 @@ El release `1.0.0` solo puede aprobarse si:
   - #35 SECURITY threat model
   - #34 API stability contract
 - P1:
-  - #36 Hardening attrs/event attrs
+  - #39 Hardening attrs/event attrs
   - #37 Scheduler API no-op
-  - #38 Coverage gate CI
-  - #39 Hardening XSS residual + alineación docs/código
-  - #40 Diff performance
+  - #36 Coverage gate CI
+  - #40 Hardening XSS residual + alineación docs/código
+  - #38 Diff performance
 
 ---
 


### PR DESCRIPTION
## Contexto

Las issues **#35 (P0)** y **#38 (P1)** permanecían abiertas pese a estar técnicamente implementadas. El problema real era de **trazabilidad documental cruzada**: los números de issue en los docs locales no correspondían a los de GitHub.

## Hallazgo

| Issue GitHub | Tema real | Número en docs (antes) |
|---|---|---|
| **#35** — SECURITY threat model | Sin entrada dedicada en evidence log | — |
| **#36** — Coverage gate en CI | `#38` | ❌ cruzado |
| **#38** — Diff performance O(1) | `#40` | ❌ cruzado |
| **#39** — Attrs/event hardening | `#36` | ❌ cruzado |
| **#40** — Docs vs código alignment | `#39` | ❌ cruzado |

## Cambios

**`docs/V1-0-0-EVIDENCE-LOG.md`**
- Añadida entrada explícita de evidencia para `#35` (SECURITY threat model, commit `3df31b8`, PR #41)
- Corregidos números de issue en todas las entradas P1 para alinear con GitHub
- Añadida nota de trazabilidad en la entrada de diff explicando el cruce histórico de commits

**`docs/V1-0-0-PLAN-TRAZABILIDAD.md`**
- Corregido backlog P1 (§4)
- Corregida matriz de trazabilidad (§6)
- Corregido mapa GitHub (§6.1)

## Verificación

- `git diff --name-only` = exactamente 2 archivos docs; sin cambios en `src/`, `tests/`, `scripts/`, `package.json`, `CHANGELOG.md`, `.github/`
- Todos los números de issue ahora corresponden 1:1 con GitHub

## Closes

Closes #35
Closes #38

Refs #30

## Summary by Sourcery

Volver a alinear la trazabilidad de la documentación de la versión v1.0.0 con los issues de GitHub para los elementos de seguridad y rendimiento.

Documentación:
- Actualizar el registro de evidencias de la v1.0.0 para corregir las referencias a issues P1 y documentar la trazabilidad histórica de la optimización de rendimiento del diff.
- Añadir una entrada de evidencia explícita para el issue de modelo de amenazas de SECURITY #35 en el registro de evidencias de la v1.0.0.
- Corregir las tablas del plan de trazabilidad y el backlog de la v1.0.0 para que todos los elementos P1 se asignen 1:1 a sus números canónicos de issues de GitHub.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Realign v1.0.0 documentation traceability with GitHub issues for security and performance items.

Documentation:
- Update the v1.0.0 evidence log to correct P1 issue references and document historical traceability for the diff performance optimization.
- Add an explicit evidence entry for the SECURITY threat model issue #35 in the v1.0.0 evidence log.
- Correct the v1.0.0 traceability plan tables and backlog so that all P1 items map 1:1 to their canonical GitHub issue numbers.

</details>