### PR TITLE
docs: establecer modelo de interacción declarativo

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const Counter = defineComponent(() => ({
     {
       type: 'element',
       tag: 'button',
-      attrs: { id: 'increment' },
+      on: { click: () => { count.value++ } },  // declarative handler — lives in the tree
       children: [{ type: 'text', content: 'Increment' }],
     },
   ],
@@ -70,14 +70,13 @@ const Counter = defineComponent(() => ({
 // --- Mount ---
 const app = createApp(Counter, document.getElementById('app')!)
 app.mount()
-
-// --- Reactivity ---
-document.getElementById('increment')!.addEventListener('click', () => {
-  count.value++  // Automatically triggers prepare → reflow → commit in next rAF
-})
 ```
 
-When `count.value` changes, Axiom automatically re-runs `prepare → reflow → commit` in the next animation frame — batching any rapid updates into a single render.
+The `on` property wires event handlers **declaratively inside the tree** — no `getElementById`, no post-render `addEventListener`. When `count.value` changes, Axiom automatically re-runs `prepare → reflow → commit` in the next animation frame — batching any rapid updates into a single render.
+
+> **Interaction model**: event handlers belong in the component tree via `on: { click, input, change, … }`.  
+> `addEventListener` on `window`, `document`, or external elements is an explicit escape hatch for  
+> browser-level integration (routing, third-party widgets) — not the default pattern.
 
 ---
 

--- a/demo/controls.ts
+++ b/demo/controls.ts
@@ -73,6 +73,10 @@ export function initControls(deps: ControlsDeps) {
 
   // ============================================================
   // DOM Controls
+  // Note: these controls are static HTML elements in the demo page
+  // (index.html / static.html) that live OUTSIDE Axiom's rendered tree.
+  // addEventListener here is the correct "browser-level integration" escape hatch.
+  // Axiom-owned elements (inside defineComponent) use `on: { event: handler }` instead.
   // ============================================================
 
   const widthSlider = document.getElementById('width-slider') as HTMLInputElement

--- a/demo/dx-showcase.ts
+++ b/demo/dx-showcase.ts
@@ -25,6 +25,10 @@ interface DevHookWindow extends Window {
 export function initDxShowcase(deps: DxShowcaseDeps): void {
   const { app } = deps
 
+  // These buttons (dx-profiling-btn, dx-hotreload-btn, etc.) are static HTML elements
+  // declared in static.html — outside Axiom's rendered tree. addEventListener is the
+  // correct "browser-level integration" pattern for controls that live outside Axiom.
+  // Axiom-owned elements use `on: { click: handler }` declared inside defineComponent.
   const profilingBtn = document.getElementById('dx-profiling-btn') as HTMLButtonElement
   const hotReloadBtn = document.getElementById('dx-hotreload-btn') as HTMLButtonElement
   const devHookRefreshBtn = document.getElementById('dx-devhook-refresh') as HTMLButtonElement

--- a/demo/ruta-b-showcase.ts
+++ b/demo/ruta-b-showcase.ts
@@ -93,6 +93,9 @@ function initGridDemo(): void {
   gridApp.mount()
 
   // Controles: añadir/quitar celdas
+  // Note: addBtn/removeBtn are static HTML elements outside the Axiom tree (in static.html).
+  // addEventListener is the correct escape hatch here. If these buttons were rendered
+  // by Axiom (inside defineComponent), they would use `on: { click: handler }` instead.
   const addBtn = document.getElementById('ruta-b-grid-add')
   const removeBtn = document.getElementById('ruta-b-grid-remove')
   const statusEl = document.getElementById('ruta-b-grid-status')
@@ -256,6 +259,10 @@ function initAnimationDemo(): void {
   const runBtn = document.getElementById('ruta-b-anim-run')
   const cancelBtn = document.getElementById('ruta-b-anim-cancel')
 
+  // Note: runBtn/cancelBtn are static HTML controls outside the Axiom tree.
+  // addEventListener here is an explicit browser-level integration escape hatch.
+  // Axiom-owned interactive nodes should declare handlers via `on: { click: ... }`.
+
   const transition = createTransition('opacity', { duration: 800, easing: 'ease-in-out' })
   const bgTransition = createTransition('backgroundColor', { duration: 600, easing: 'ease-out', delay: 100 })
 
@@ -318,6 +325,10 @@ function initPluginDemo(): void {
   const updateBtn = document.getElementById('ruta-b-plugin-update')
   const unmountBtn = document.getElementById('ruta-b-plugin-unmount')
   const clearBtn = document.getElementById('ruta-b-plugin-clear')
+
+  // Note: plugin demo controls are static HTML outside Axiom's rendered tree.
+  // addEventListener is the correct escape hatch for these external controls.
+  // If rendered by Axiom, handlers should live in `on: { click: ... }`.
 
   if (logEl === null) return
   const log = logEl

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,11 +35,9 @@ to avoid type duplication during the current refactor stage.
 
 ### Type-only boundary notes
 
-- `src/core/types.ts` currently references `SafeStyleProps` as a type-only import from
-	`src/features/style.ts`.
+- `src/core/types.ts` currently references `SafeStyleProps` as a type-only import from `src/features/style.ts`.
 - `src/render/{prepare,diff}.ts` also use type-only references to `SafeStyleProps`.
-- This does **not** imply runtime coupling. A future cleanup may relocate shared style types
-	into `core/` if we decide to eliminate these type-only bridges.
+- This does **not** imply runtime coupling. A future cleanup may relocate shared style types into `core/` if we decide to eliminate these type-only bridges.
 
 ## Architectural Exception
 
@@ -52,3 +50,45 @@ Documented in [PLAN-REFACTOR-SRC-HIBRIDO.md](./PLAN-REFACTOR-SRC-HIBRIDO.md) and
 `src/index.ts` is the **only** surface consumers should import from. Internal modules are implementation details and may change between minor versions without semver guarantees.
 
 Exception: `commitHydrate` is exported as an advanced hydration API.
+
+---
+
+## Interaction Model
+
+> **"The DOM is just the output screen."**  
+> UI owned by Axiom must also be _driven_ by Axiom — declaratively, inside the tree.
+
+### Canonical pattern: component-first events
+
+Event handlers live in the component tree via the `on` property:
+
+```typescript
+defineComponent(() => ({
+  type: 'element',
+  tag: 'button',
+  on: { click: () => { count.value++ } },   // handler declared in tree
+  children: [{ type: 'text', content: 'Increment' }],
+}))
+```
+
+`on` is defined on `ElementNode` (`src/core/types.ts`), wired by `prepare.ts`, diffed by
+`diff.ts`, and applied by `commit.ts`. No post-render DOM query is needed.
+
+### Escape hatch: browser-level integration
+
+`window.addEventListener`, `document.addEventListener`, and `popstate` are legitimate for:
+
+- **Client-side router** — `popstate` / `hashchange` listeners (`src/router.ts`)
+- **Third-party widgets** — elements whose lifecycle Axiom does not own
+- **Demo control panels** — static HTML controls that drive an Axiom canvas from outside
+
+These cases must be clearly scoped (module-level or component teardown) and are **not** the
+default interaction pattern. When the element being interacted with belongs to the Axiom tree,
+use `on: {}` instead.
+
+### Rule summary
+
+| Element belongs to Axiom tree? | Pattern |
+| ------------------------------ | ------- |
+| Yes                            | `on: { click: () => { signal.value++ } }` |
+| No (browser / external)        | `addEventListener` as explicit escape hatch |

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "homepage": "https://github.com/naml14/axiom-framework#readme",
   "devDependencies": {
     "@types/bun": "1.3.11",
-    "happy-dom": "^20.8.9",
+    "happy-dom": "^20.9.0",
     "ts-morph": "^24.0.0",
-    "typescript": "^6.0.2"
+    "typescript": "^6.0.3"
   }
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -202,3 +202,163 @@ describe('integration: SSR -> hydrate -> interaction', () => {
     expect((root?.getElementsByTagName('button')[0] ?? null)?.textContent).toContain('Count: 1')
   })
 })
+
+// ============================================================
+// Integration: signal → declarative event → rerender
+// Verifies the canonical component-first interaction model:
+//   on: { click: handler } is the primary way to wire Axiom-owned elements.
+//   No getElementById, no post-render addEventListener.
+// ============================================================
+
+describe('integration: signal → declarative on-handler → rerender', () => {
+  test('click handler declarado en on:{} muta signal y provoca rerender', () => {
+    const count = signal(0)
+
+    const Counter = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'button',
+          on: { click: () => { count.value++ } },
+          children: [{ type: 'text' as const, content: `Count: ${count.value}` }],
+        },
+      ],
+    }))
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp(Counter, root, {
+      textEngine: fakeTextEngine,
+      scheduler: (cb) => cb(),
+    })
+    app.mount()
+
+    const btn = root.getElementsByTagName('button')[0]
+    expect(btn).toBeDefined()
+    expect(btn?.textContent).toContain('Count: 0')
+
+    btn?.dispatchEvent(new window.Event('click'))
+
+    // After click: signal changed → performUpdate → rerender
+    expect(count.value).toBe(1)
+    const btnAfter = root.getElementsByTagName('button')[0]
+    expect(btnAfter?.textContent).toContain('Count: 1')
+
+    app.unmount()
+  })
+
+  test('múltiples clicks acumulan el estado correctamente', () => {
+    const count = signal(0)
+
+    const Counter = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'button',
+          on: { click: () => { count.value++ } },
+          children: [{ type: 'text' as const, content: `${count.value}` }],
+        },
+      ],
+    }))
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp(Counter, root, {
+      textEngine: fakeTextEngine,
+      scheduler: (cb) => cb(),
+    })
+    app.mount()
+
+    const btn = () => root.getElementsByTagName('button')[0]
+
+    btn()?.dispatchEvent(new window.Event('click'))
+    btn()?.dispatchEvent(new window.Event('click'))
+    btn()?.dispatchEvent(new window.Event('click'))
+
+    expect(count.value).toBe(3)
+    expect(btn()?.textContent).toBe('3')
+
+    app.unmount()
+  })
+
+  test('handler declarado con on:{input} responde a evento input', () => {
+    const text = signal('')
+
+    const Input = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'span',
+          on: {
+            input: (e: Event) => {
+              text.value = (e.target as HTMLInputElement).value ?? 'triggered'
+            },
+          },
+          children: [{ type: 'text' as const, content: text.value }],
+        },
+      ],
+    }))
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp(Input, root, {
+      textEngine: fakeTextEngine,
+      scheduler: (cb) => cb(),
+    })
+    app.mount()
+
+    const span = root.getElementsByTagName('span')[0]
+    const event = new window.Event('input')
+    Object.defineProperty(event, 'target', { value: { value: 'hello' }, writable: false })
+    span?.dispatchEvent(event)
+
+    expect(text.value).toBe('hello')
+
+    app.unmount()
+  })
+
+  test('no se necesita getElementById ni addEventListener post-render para elementos del árbol Axiom', () => {
+    // Este test sirve como documentación ejecutable del principio:
+    // cualquier elemento renderizado por Axiom debe usar on:{} para interacción.
+    // El patrón anti-principio sería: document.getElementById('btn')?.addEventListener(...)
+    const clicked = signal(false)
+
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'section',
+      children: [
+        {
+          type: 'element' as const,
+          tag: 'button',
+          // ✅ handler declarativo — no getElementById, no post-render addEventListener
+          on: { click: () => { clicked.value = true } },
+          children: [{ type: 'text' as const, content: 'Act' }],
+        },
+      ],
+    }))
+
+    const root = document.createElement('div')
+    document.body.appendChild(root)
+
+    const app = createApp(App, root, {
+      textEngine: fakeTextEngine,
+      scheduler: (cb) => cb(),
+    })
+    app.mount()
+
+    expect(clicked.value).toBe(false)
+    root.getElementsByTagName('button')[0]?.dispatchEvent(new window.Event('click'))
+    expect(clicked.value).toBe(true)
+
+    app.unmount()
+  })
+})

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -248,6 +248,7 @@ describe('integration: signal → declarative on-handler → rerender', () => {
     expect(btnAfter?.textContent).toContain('Count: 1')
 
     app.unmount()
+    root.remove()
   })
 
   test('múltiples clicks acumulan el estado correctamente', () => {
@@ -285,6 +286,7 @@ describe('integration: signal → declarative on-handler → rerender', () => {
     expect(btn()?.textContent).toBe('3')
 
     app.unmount()
+    root.remove()
   })
 
   test('handler declarado con on:{input} responde a evento input', () => {
@@ -324,6 +326,7 @@ describe('integration: signal → declarative on-handler → rerender', () => {
     expect(text.value).toBe('hello')
 
     app.unmount()
+    root.remove()
   })
 
   test('no se necesita getElementById ni addEventListener post-render para elementos del árbol Axiom', () => {
@@ -360,5 +363,6 @@ describe('integration: signal → declarative on-handler → rerender', () => {
     expect(clicked.value).toBe(true)
 
     app.unmount()
+    root.remove()
   })
 })


### PR DESCRIPTION
## Resumen
Este PR alinea la superficie pública del framework con el principio de Axiom: la UI del árbol debe declarar interacción con on: { event: handler }, dejando AddEventListener como escape hatch para integraciones externas.

## Cambios
- Documentación arquitectónica del modelo de interacción (docs/ARCHITECTURE.md).
- Quickstart actualizado a handlers declarativos (README.md).
- Tests de integración para signal -> evento declarativo -> rerender (	ests/integration.test.ts).
- Comentarios de guía en demos con controles HTML fuera del árbol Axiom (demo/controls.ts, demo/dx-showcase.ts, demo/ruta-b-showcase.ts).

## Validación
- bun test tests/integration.test.ts
- bun run typecheck

## Notas
No se modifica runtime (src/), ya que el mecanismo declarativo ya estaba implementado.

## Summary by Sourcery

Documentar y validar el modelo de interacción declarativo, enfatizando los manejadores `on:{}` en el árbol de componentes como la forma principal de conectar eventos, reservando `addEventListener` del DOM como una vía de escape para controles externos.

Documentación:
- Ampliar la guía de arquitectura con una sección explícita sobre el modelo de interacción que describa los manejadores declarativos `on:{}` y el papel de vía de escape de `addEventListener`.
- Actualizar el ejemplo de inicio rápido del README para usar manejadores de eventos declarativos `on:{}` dentro del árbol de componentes en lugar de consultas imperativas al DOM.

Tests:
- Añadir tests de integración que cubran la propagación de actualizaciones de señales a través de manejadores de eventos declarativos `on:{}` para disparar rerenders y acumular estado.

Chores:
- Anotar los scripts de controles de demostración con indicaciones que expliquen que `addEventListener` está pensado solo para controles HTML estáticos fuera del árbol de Axiom y que los elementos propiedad de Axiom deben usar manejadores declarativos `on:{}`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Document and validate the declarative interaction model, emphasizing `on:{}` handlers in the component tree as the primary way to wire events, with DOM `addEventListener` reserved as an escape hatch for external controls.

Documentation:
- Extend the architecture guide with an explicit interaction model section describing declarative `on:{}` handlers and the escape-hatch role of `addEventListener`.
- Update the README quickstart example to use declarative `on:{}` event handlers within the component tree instead of imperative DOM queries.

Tests:
- Add integration tests that cover signal updates flowing through declarative `on:{}` event handlers to trigger rerenders and accumulate state.

Chores:
- Annotate demo control scripts with guidance explaining that `addEventListener` is intended only for static HTML controls outside the Axiom tree and that Axiom-owned elements should use declarative `on:{}` handlers.

</details>