### PR TITLE
fix(create-axiom): pin starter dependency version

### DIFF
--- a/scripts/create-axiom.ts
+++ b/scripts/create-axiom.ts
@@ -10,6 +10,19 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMPLATES_DIR = join(__dirname, "templates");
+const ROOT_PACKAGE_JSON_PATH = join(__dirname, "..", "package.json");
+
+async function getCurrentFrameworkVersion(): Promise<string> {
+	const rootPackage = JSON.parse(
+		await readFile(ROOT_PACKAGE_JSON_PATH, "utf8"),
+	) as { version?: string };
+
+	if (!rootPackage.version) {
+		throw new Error("Could not determine the current axiom-framework version");
+	}
+
+	return rootPackage.version;
+}
 
 export const TEMPLATE_FILES: Array<[string, string]> = [
 	["package.json", "package.json"],
@@ -27,14 +40,22 @@ export async function scaffoldProject(
 ): Promise<void> {
 	await mkdir(projectDir, { recursive: true });
 	await mkdir(join(projectDir, "src"), { recursive: true });
+	const frameworkVersion = await getCurrentFrameworkVersion();
 
 	for (const [src, dest] of TEMPLATE_FILES) {
 		const content = await readFile(join(TEMPLATES_DIR, src), "utf8");
 		let final = content;
 
 		if (src === "package.json") {
-			const pkg = JSON.parse(content) as { name?: string };
+			const pkg = JSON.parse(content) as {
+				name?: string;
+				dependencies?: Record<string, string>;
+			};
 			pkg.name = projectName;
+			pkg.dependencies = {
+				...(pkg.dependencies ?? {}),
+				"axiom-framework": frameworkVersion,
+			};
 			final = `${JSON.stringify(pkg, null, 2)}\n`;
 		}
 

--- a/scripts/templates/package.json
+++ b/scripts/templates/package.json
@@ -9,7 +9,7 @@
     "typecheck": "bunx tsc --noEmit"
   },
   "dependencies": {
-    "axiom-framework": "^0.9.0"
+    "axiom-framework": "__AXIOM_FRAMEWORK_VERSION__"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/tests/create-axiom.test.ts
+++ b/tests/create-axiom.test.ts
@@ -123,6 +123,12 @@ describe("create-axiom starter", () => {
 		const projectDir = await scaffoldStarterProject("scaffold");
 
 		const indexHtml = await readFile(join(projectDir, "index.html"), "utf8");
+		const generatedPackage = JSON.parse(
+			await readFile(join(projectDir, "package.json"), "utf8"),
+		) as { dependencies?: Record<string, string> };
+		const rootPackage = JSON.parse(
+			await readFile(join(repoRoot, "package.json"), "utf8"),
+		) as { version: string };
 		const starterStyles = await readFile(
 			join(projectDir, "src", "styles.css"),
 			"utf8",
@@ -132,6 +138,9 @@ describe("create-axiom starter", () => {
 			/<link\s+rel="stylesheet"\s+href="\/src\/styles\.css"\s*\/?>/,
 		);
 		expect(indexHtml).toContain('src="/src/app.ts"');
+		expect(generatedPackage.dependencies?.["axiom-framework"]).toBe(
+			rootPackage.version,
+		);
 		expect(starterStyles).toContain("h1,");
 		expect(starterStyles).toContain("button {");
 	});


### PR DESCRIPTION
## Summary
- pin the scaffolded `axiom-framework` dependency to the exact version of the package running `create-axiom`
- remove the stale hardcoded starter dependency range from the template
- lock the behavior with a regression test that checks exact version equality

## Type of change
- [x] `fix` — bug fix (patch bump)
- [ ] `feat` — new feature (minor bump)
- [ ] `feat!` / `BREAKING CHANGE` — breaking change (major bump)
- [ ] `perf` — performance improvement (patch bump)
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only
- [ ] `docs` — documentation only
- [ ] `ci` — workflow changes
- [ ] `chore` — maintenance

## Changes
| File | Change |
|------|--------|
| `scripts/create-axiom.ts` | Read the current package version and write it into the generated starter dependency |
| `scripts/templates/package.json` | Remove the stale hardcoded `axiom-framework` semver range |
| `tests/create-axiom.test.ts` | Assert that the generated starter depends on the exact current framework version |

## Checklist
- [x] Tests added or updated for the changed behavior
- [x] `bun test` passes locally (all tests green)
- [x] `bun run typecheck` passes locally
- [x] This PR links at least one issue (`Closes #...`)
- [x] `docs/V1-0-0-EVIDENCE-LOG.md` was updated (or marked N/A with reason)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] Hot path invariant respected: no DOM reads added to `src/render/reflow.ts`, `src/render/engines/fast-path.ts`, `src/render/engines/flex.ts`, or `src/render/commit.ts`
- [x] No runtime dependencies added to `src/`

## Related issues
Closes #63

## Testing notes
- `bun run typecheck`
- `bun run test:coverage`
- `bun run build`
- real scaffold reproduction via `bun scripts/create-axiom.ts new-app`
- verified generated `new-app/package.json` contains `"axiom-framework": "0.9.7"`
- `docs/V1-0-0-EVIDENCE-LOG.md`: N/A, no product-facing docs changed

## Summary by Sourcery

Asegura que `create-axiom` genere proyectos iniciales (starters) que dependan de la versión exacta de `axiom-framework` utilizada por el paquete CLI.

Bug Fixes:
- Corrige que los proyectos iniciales generados dependan incorrectamente de un rango de versiones codificado de `axiom-framework` en lugar de la versión actual del framework.

Tests:
- Agrega una prueba de regresión que verifica que el `package.json` generado para el starter dependa exactamente de la versión actual de `axiom-framework`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure create-axiom scaffolds starters that depend on the exact version of axiom-framework used by the CLI package.

Bug Fixes:
- Fix scaffolded starter projects incorrectly depending on a hardcoded axiom-framework version range instead of the current framework version.

Tests:
- Add a regression test asserting the generated starter package.json depends on the exact current axiom-framework version.

</details>