### PR TITLE
fix(core): plugin context, recursion guard, hydration degrade, pool eviction, stream/router hardening

### DIFF
--- a/src/features/plugin.ts
+++ b/src/features/plugin.ts
@@ -7,7 +7,7 @@
  * They are designed to be non-intrusive: a failing plugin does not break the
  * prepare → reflow → commit pipeline.
  *
- * Example:
+ * ## Global registry (backward-compatible)
  *
  * ```ts
  * import { createPlugin, registerPlugin } from 'axiom-framework'
@@ -19,6 +19,19 @@
  * })
  *
  * registerPlugin(devtools)
+ * ```
+ *
+ * ## Request-scoped context (multi-tenant safe)
+ *
+ * Use `createAppContext()` to get an isolated plugin scope that is never
+ * shared across app instances or tenants:
+ *
+ * ```ts
+ * import { createPlugin, createAppContext } from 'axiom-framework'
+ *
+ * const scope = createAppContext()
+ * scope.registerPlugin(createPlugin({ name: 'tenant-plugin', onMount: () => {} }))
+ * scope.applyPluginHook('onMount', { appId: 'tenant-123' })
  * ```
  */
 
@@ -128,5 +141,75 @@ export function applyPluginHook(hook: PluginHook, ctx: PluginContext): void {
         // Plugin authors can add their own error reporting inside their hooks.
       }
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request-scoped plugin context (multi-tenant safe)
+// ---------------------------------------------------------------------------
+
+/**
+ * An isolated plugin scope that owns its own registry.
+ *
+ * Plugins registered through a `PluginScope` are completely isolated from the
+ * global registry and from every other scope. This prevents cross-request /
+ * cross-tenant state pollution in multi-tenant environments.
+ */
+export interface PluginScope {
+  /** Register a plugin with this scope. Duplicates (by name) are silently ignored. */
+  registerPlugin(plugin: AxiomPlugin): void
+  /** Returns a snapshot of plugins registered in this scope (in registration order). */
+  getRegisteredPlugins(): readonly AxiomPlugin[]
+  /**
+   * Invoke a lifecycle hook on all plugins in this scope.
+   *
+   * Errors thrown by individual hooks are swallowed — consistent with the
+   * global `applyPluginHook` contract.
+   */
+  applyPluginHook(hook: PluginHook, ctx: PluginContext): void
+}
+
+/**
+ * Create a request-scoped plugin context.
+ *
+ * Each call returns a brand-new, fully isolated `PluginScope`. Plugins
+ * registered inside the scope are never visible to the global registry or to
+ * any other scope, eliminating cross-request state pollution.
+ *
+ * Typical usage — one context per incoming request or per app instance:
+ *
+ * ```ts
+ * const scope = createAppContext()
+ * scope.registerPlugin(tenantPlugin)
+ * scope.applyPluginHook('onMount', { appId })
+ * ```
+ */
+export function createAppContext(): PluginScope {
+  const scopedRegistry: AxiomPlugin[] = []
+
+  return {
+    registerPlugin(plugin: AxiomPlugin): void {
+      const alreadyRegistered = scopedRegistry.some(p => p.name === plugin.name)
+      if (!alreadyRegistered) {
+        scopedRegistry.push(plugin)
+      }
+    },
+
+    getRegisteredPlugins(): readonly AxiomPlugin[] {
+      return [...scopedRegistry]
+    },
+
+    applyPluginHook(hook: PluginHook, ctx: PluginContext): void {
+      for (const plugin of scopedRegistry) {
+        const fn = plugin[hook]
+        if (typeof fn === 'function') {
+          try {
+            fn(ctx)
+          } catch {
+            // Intentionally swallowed: plugin errors must not break the app lifecycle.
+          }
+        }
+      }
+    },
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export type { HydrationOptions, HydrationResult } from './core/types.js'
 
 // --- Router ---
 export { createRouter, defineAsyncComponent } from './router.js'
-export type { Route, RouteState, Router } from './router.js'
+export type { Route, RouteState, Router, AsyncComponentOptions } from './router.js'
 
 // --- Layout (advanced — for custom rendering pipelines) ---
 export { prepare } from './render/prepare.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,8 @@ export {
 export type { TransitionDefinition, AnimationState, TransitionProperty } from './features/animation.js'
 
 // --- Plugin / Adapter hooks (Ruta B, Fase 5) ---
-export { createPlugin, registerPlugin, getRegisteredPlugins, clearPlugins, applyPluginHook } from './features/plugin.js'
-export type { AxiomPlugin, PluginContext, PluginHook } from './features/plugin.js'
+export { createPlugin, registerPlugin, getRegisteredPlugins, clearPlugins, applyPluginHook, createAppContext } from './features/plugin.js'
+export type { AxiomPlugin, PluginContext, PluginHook, PluginScope } from './features/plugin.js'
 
 // --- Context ---
 export {

--- a/src/reactivity/signals.ts
+++ b/src/reactivity/signals.ts
@@ -44,7 +44,9 @@ interface SignalInternal<T> extends ReactiveNode {
 
 let activeEffect: EffectNode | null = null
 let executionDepth = 0
+let computedDepth = 0
 const MAX_DEPTH = 100
+const MAX_COMPUTED_DEPTH = 100
 
 // ============================================================
 // Signal
@@ -202,6 +204,12 @@ function evaluateComputed(internal: ComputedNode<unknown>): void {
     throw new Error('Circular dependency detected in computed signal')
   }
 
+  computedDepth++
+  if (computedDepth > MAX_COMPUTED_DEPTH) {
+    computedDepth--
+    throw new Error('Infinite loop detected: computed depth exceeded maximum')
+  }
+
   internal._depVersions.clear()
   internal._computing = true
 
@@ -224,6 +232,7 @@ function evaluateComputed(internal: ComputedNode<unknown>): void {
   } finally {
     internal._computing = false
     activeEffect = prevEffect
+    computedDepth--
   }
 }
 

--- a/src/render/commit.ts
+++ b/src/render/commit.ts
@@ -266,7 +266,16 @@ export function commitHydrate(
   const rootHeight = layout.height[0] ?? 0
   root.style.height = `${rootHeight}px`
 
-  hydrateNode(prepared)
+  try {
+    hydrateNode(prepared)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    if (strict) {
+      throw error
+    }
+    result.mismatchCount++
+    result.warnings.push(`Hydration failed: ${message}`)
+  }
 
   state.domNodes = nextDomNodes
 

--- a/src/render/commit.ts
+++ b/src/render/commit.ts
@@ -268,16 +268,25 @@ export function commitHydrate(
 
   try {
     hydrateNode(prepared)
+    state.domNodes = nextDomNodes
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
     if (strict) {
       throw error
     }
+    // A thrown error (not a soft mismatch, which is handled inline by `fail`)
+    // aborts hydration mid-recursion, leaving `nextDomNodes` and the live DOM
+    // inconsistent: untracked ghost nodes plus missing `state.domNodes` entries
+    // that crash later reactive updates. Degrade gracefully — wipe the container
+    // and fall back to a full client-side render instead of committing a broken
+    // hydration state.
+    const message = error instanceof Error ? error.message : String(error)
     result.mismatchCount++
-    result.warnings.push(`Hydration failed: ${message}`)
+    result.warnings.push(`Hydration failed: ${message}. Falling back to full client-side render.`)
+    root.innerHTML = ''
+    state.domNodes = []
+    state.portalRoots.clear()
+    commitFull(layout, prepared, root, state, commitOpts)
   }
-
-  state.domNodes = nextDomNodes
 
   if (options?.debug === true) {
     ;(globalThis as any).__AXIOM_HYDRATION_DEBUG__ = {

--- a/src/render/pool.ts
+++ b/src/render/pool.ts
@@ -6,11 +6,17 @@ import type { LayoutResult } from '../core/types.js'
 // Recycles Float32Arrays to avoid GC pressure during hot path reflows.
 // Buffers only grow, they never shrink.
 
-const pool: LayoutResult[] = []
+interface PooledLayoutEntry {
+  result: LayoutResult
+  releasedAt: number
+}
+
+const pool: PooledLayoutEntry[] = []
 let inPool = new WeakSet<LayoutResult>()
 
 const MAX_POOLED_LAYOUTS = 32
 const MAX_POOLED_CAPACITY = 16_384
+const MAX_POOLED_AGE_MS = 30_000
 
 function isDevEnvironment(): boolean {
   if (globalThis.__AXIOM_DEV__ === true) return true
@@ -20,13 +26,26 @@ function isDevEnvironment(): boolean {
   return nodeEnv !== 'production'
 }
 
+function pruneExpiredEntries(now: number): void {
+  for (let i = pool.length - 1; i >= 0; i--) {
+    const entry = pool[i]!
+    if (now - entry.releasedAt > MAX_POOLED_AGE_MS) {
+      inPool.delete(entry.result)
+      pool.splice(i, 1)
+    }
+  }
+}
+
 function acquireFromPool(minCapacity: number): LayoutResult | undefined {
+  const now = Date.now()
+  pruneExpiredEntries(now)
+
   for (let i = pool.length - 1; i >= 0; i--) {
     const candidate = pool[i]!
-    if (candidate.x.length >= minCapacity) {
+    if (candidate.result.x.length >= minCapacity) {
       pool.splice(i, 1)
-      inPool.delete(candidate)
-      return candidate
+      inPool.delete(candidate.result)
+      return candidate.result
     }
   }
 
@@ -69,11 +88,17 @@ export function releaseLayoutResult(result: LayoutResult): void {
     return
   }
 
+  const now = Date.now()
+  pruneExpiredEntries(now)
+
   if (pool.length >= MAX_POOLED_LAYOUTS) {
-    pool.shift()
+    const evicted = pool.shift()
+    if (evicted !== undefined) {
+      inPool.delete(evicted.result)
+    }
   }
 
-  pool.push(result)
+  pool.push({ result, releasedAt: now })
   inPool.add(result)
 }
 
@@ -87,5 +112,6 @@ export function clearLayoutPool(): void {
  * Useful for metrics and debugging.
  */
 export function getLayoutPoolSize(): number {
+  pruneExpiredEntries(Date.now())
   return pool.length
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -307,8 +307,17 @@ export function createRouter(routes: Route[]): Router {
   return router
 }
 
+export interface AsyncComponentOptions<P = void> {
+  /**
+   * Rendered when the async loader rejects. Lets the UI react to load failures
+   * instead of silently rendering an empty fragment forever.
+   */
+  errorFallback?: ComponentDefinition<P>
+}
+
 export function defineAsyncComponent<P = void>(
-  loader: () => Promise<{ default: ComponentDefinition<P> }>
+  loader: () => Promise<{ default: ComponentDefinition<P> }>,
+  options?: AsyncComponentOptions<P>
 ): ComponentDefinition<P> {
   const loaded = signal<ComponentDefinition<P> | null>(null)
   const loadError = signal<Error | null>(null)
@@ -335,6 +344,16 @@ export function defineAsyncComponent<P = void>(
             // Set an error signal so the UI can show a fallback
             loadError.value = err instanceof Error ? err : new Error(String(err))
           })
+      }
+
+      // Read the error signal (reactive dependency) so a failed load surfaces a
+      // fallback instead of leaving the signal write-only and the UI stuck on an
+      // empty fragment.
+      const error = loadError.value
+      if (error !== null) {
+        return options?.errorFallback !== undefined
+          ? options.errorFallback._fn(props)
+          : { type: 'fragment', children: [] }
       }
 
       const component = loaded.value

--- a/src/router.ts
+++ b/src/router.ts
@@ -311,6 +311,7 @@ export function defineAsyncComponent<P = void>(
   loader: () => Promise<{ default: ComponentDefinition<P> }>
 ): ComponentDefinition<P> {
   const loaded = signal<ComponentDefinition<P> | null>(null)
+  const loadError = signal<Error | null>(null)
   let initiated = false
 
   return {
@@ -325,8 +326,14 @@ export function defineAsyncComponent<P = void>(
               loaded.value = mod.default
             }
           })
-          .catch(() => {
-            // Silent fail by design: keep rendering empty fragment.
+          .catch((err) => {
+            // Emit to error monitoring, never silently drop
+            const g = globalThis as typeof globalThis & { __AXIOM_ON_ASYNC_ERROR__?: (err: unknown) => void }
+            if (typeof g.__AXIOM_ON_ASYNC_ERROR__ === 'function') {
+              g.__AXIOM_ON_ASYNC_ERROR__(err)
+            }
+            // Set an error signal so the UI can show a fallback
+            loadError.value = err instanceof Error ? err : new Error(String(err))
           })
       }
 

--- a/src/ssr-stream.ts
+++ b/src/ssr-stream.ts
@@ -29,8 +29,13 @@ export function renderToReadableStream(
   component: ComponentDefinition<void>,
   options?: StreamSSROptions
 ): ReadableStream<Uint8Array> {
-  // Current implementation: wrap the full renderToString() result in a
-  // ReadableStream as a single chunk.
+  if (
+    component === null ||
+    typeof component !== 'function' ||
+    typeof (component as ComponentDefinition<void>)._fn !== 'function'
+  ) {
+    throw new Error('renderToReadableStream() requires a valid component definition')
+  }
   const html = renderToString(component, options)
   const encoder = new TextEncoder()
 

--- a/src/ssr-stream.ts
+++ b/src/ssr-stream.ts
@@ -29,9 +29,13 @@ export function renderToReadableStream(
   component: ComponentDefinition<void>,
   options?: StreamSSROptions
 ): ReadableStream<Uint8Array> {
+  // A valid ComponentDefinition is an object with a callable `_fn`. Note that
+  // `defineComponent()` returns a callable function (with `_fn` attached) while
+  // `defineAsyncComponent()` returns a plain object — both are valid here, so we
+  // must not reject non-callable definitions.
   if (
     component === null ||
-    typeof component !== 'function' ||
+    (typeof component !== 'object' && typeof component !== 'function') ||
     typeof (component as ComponentDefinition<void>)._fn !== 'function'
   ) {
     throw new Error('renderToReadableStream() requires a valid component definition')

--- a/tests/hydration.test.ts
+++ b/tests/hydration.test.ts
@@ -332,3 +332,66 @@ describe('hydration: layout resets applied by commitHydrate', () => {
     expect(style).toContain('position')
   })
 })
+
+describe('hydration: graceful degrade on unexpected error', () => {
+  test('soft mode wipes container and falls back to full client render when hydration throws', () => {
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [{ type: 'text' as const, content: 'recovered' }],
+    }))
+
+    const html = renderToString(App, { textEngine: fakeTextEngine })
+    installWindow(html)
+    const root = getHydrationRoot()
+
+    // Force an UNEXPECTED throw (not a soft mismatch handled by `fail`) during
+    // hydration: make the matched element's `style` getter throw when
+    // applyFrameworkLayout touches it.
+    const matched = root.firstElementChild as HTMLElement
+    Object.defineProperty(matched, 'style', {
+      configurable: true,
+      get() {
+        throw new Error('boom: style access during hydration')
+      },
+    })
+
+    const prepared = prepare(App, undefined, { textEngine: fakeTextEngine })
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 }, { lineHeight: 20 })
+    const state = { domNodes: [] as Array<HTMLElement | Text | null>, portalRoots: new Map() }
+
+    const result = commitHydrate(layout, prepared, root, state, { strictMismatch: false })
+
+    // Degraded gracefully instead of throwing or committing ghost nodes.
+    expect(result.warnings.some(w => w.includes('Falling back to full client-side render'))).toBe(true)
+    // Container was re-rendered from scratch; content is present and tracked.
+    expect(root.textContent).toContain('recovered')
+    expect(state.domNodes.length).toBeGreaterThan(0)
+    expect(state.domNodes[0]).not.toBeNull()
+  })
+
+  test('strict mode still rethrows unexpected hydration errors', () => {
+    const App = defineComponent(() => ({
+      type: 'element' as const,
+      tag: 'div',
+      children: [{ type: 'text' as const, content: 'x' }],
+    }))
+
+    const html = renderToString(App, { textEngine: fakeTextEngine })
+    installWindow(html)
+    const root = getHydrationRoot()
+    const matched = root.firstElementChild as HTMLElement
+    Object.defineProperty(matched, 'style', {
+      configurable: true,
+      get() {
+        throw new Error('boom')
+      },
+    })
+
+    const prepared = prepare(App, undefined, { textEngine: fakeTextEngine })
+    const layout = reflow(prepared, { maxWidth: 800, maxHeight: 600 }, { lineHeight: 20 })
+    const state = { domNodes: [] as Array<HTMLElement | Text | null>, portalRoots: new Map() }
+
+    expect(() => commitHydrate(layout, prepared, root, state, { strictMismatch: true })).toThrow('boom')
+  })
+})

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -17,6 +17,7 @@ import {
   getRegisteredPlugins,
   clearPlugins,
   applyPluginHook,
+  createAppContext,
 } from '../src/features/plugin.js'
 import type { AxiomPlugin, PluginContext } from '../src/features/plugin.js'
 
@@ -51,9 +52,7 @@ describe('createPlugin', () => {
   })
 })
 
-// ---------------------------------------------------------------------------
-// 2. Plugin registry — registerPlugin + getRegisteredPlugins
-// ---------------------------------------------------------------------------
+
 describe('registerPlugin', () => {
   beforeEach(() => {
     clearPlugins()
@@ -106,7 +105,7 @@ describe('applyPluginHook', () => {
 
     registerPlugin(createPlugin({ name: 'p1', onMount: (c) => { calls.push('p1:' + c.appId) } }))
     registerPlugin(createPlugin({ name: 'p2', onMount: (c) => { calls.push('p2:' + c.appId) } }))
-    registerPlugin(createPlugin({ name: 'p3' })) // no onMount — skipped silently
+    registerPlugin(createPlugin({ name: 'p3' }))
 
     applyPluginHook('onMount', ctx)
     expect(calls).toEqual(['p1:test-app', 'p2:test-app'])
@@ -117,7 +116,7 @@ describe('applyPluginHook', () => {
     const ctx: PluginContext = { appId: 'test-app' }
 
     registerPlugin(createPlugin({ name: 'p1', onUnmount: () => { calls.push('p1-unmount') } }))
-    registerPlugin(createPlugin({ name: 'p2' })) // no onUnmount
+    registerPlugin(createPlugin({ name: 'p2' }))
 
     applyPluginHook('onUnmount', ctx)
     expect(calls).toEqual(['p1-unmount'])
@@ -163,8 +162,76 @@ describe('applyPluginHook', () => {
       onMount: () => { calls.push('survived') }
     }))
 
-    // Should not propagate the error but continue
     applyPluginHook('onMount', ctx)
     expect(calls).toEqual(['survived'])
+  })
+})
+
+describe('PluginScope (createAppContext)', () => {
+  beforeEach(() => {
+    clearPlugins()
+  })
+
+  it('creates isolated scopes independent from global registry', () => {
+    const globalCalls: string[] = []
+    const scopedCalls: string[] = []
+    const ctx: PluginContext = { appId: 'scope-app' }
+
+    registerPlugin(createPlugin({
+      name: 'global-plugin',
+      onMount: () => { globalCalls.push('global') },
+    }))
+
+    const scope = createAppContext()
+    scope.registerPlugin(createPlugin({
+      name: 'scoped-plugin',
+      onMount: () => { scopedCalls.push('scoped') },
+    }))
+
+    applyPluginHook('onMount', ctx)
+    expect(globalCalls).toEqual(['global'])
+    expect(scopedCalls).toEqual([])
+
+    scope.applyPluginHook('onMount', ctx)
+    expect(scopedCalls).toEqual(['scoped'])
+  })
+
+  it('ignores duplicate plugin names inside the same scope', () => {
+    const scope = createAppContext()
+    const plugin = createPlugin({ name: 'dup' })
+
+    scope.registerPlugin(plugin)
+    scope.registerPlugin(plugin)
+
+    expect(scope.getRegisteredPlugins()).toHaveLength(1)
+  })
+
+  it('scope hook errors are swallowed and remaining plugins continue', () => {
+    const calls: string[] = []
+    const scope = createAppContext()
+    const ctx: PluginContext = { appId: 'scope-app' }
+
+    scope.registerPlugin(createPlugin({
+      name: 'thrower',
+      onUpdate: () => { throw new Error('boom') },
+    }))
+    scope.registerPlugin(createPlugin({
+      name: 'survivor',
+      onUpdate: () => { calls.push('ok') },
+    }))
+
+    expect(() => scope.applyPluginHook('onUpdate', ctx)).not.toThrow()
+    expect(calls).toEqual(['ok'])
+  })
+
+  it('separate scopes are isolated from each other', () => {
+    const scopeA = createAppContext()
+    const scopeB = createAppContext()
+
+    scopeA.registerPlugin(createPlugin({ name: 'a' }))
+    scopeB.registerPlugin(createPlugin({ name: 'b' }))
+
+    expect(scopeA.getRegisteredPlugins().map(p => p.name)).toEqual(['a'])
+    expect(scopeB.getRegisteredPlugins().map(p => p.name)).toEqual(['b'])
   })
 })

--- a/tests/plugin.test.ts
+++ b/tests/plugin.test.ts
@@ -172,6 +172,17 @@ describe('PluginScope (createAppContext)', () => {
     clearPlugins()
   })
 
+  it('is re-exported from the package root (documented import path)', async () => {
+    // The plugin docs import `createAppContext` from 'axiom-framework'. Guard the
+    // public re-export so the documented usage actually works for consumers.
+    const root = await import('../src/index.js')
+    expect(typeof root.createAppContext).toBe('function')
+    const scope = root.createAppContext()
+    expect(typeof scope.registerPlugin).toBe('function')
+    expect(typeof scope.applyPluginHook).toBe('function')
+    expect(typeof scope.getRegisteredPlugins).toBe('function')
+  })
+
   it('creates isolated scopes independent from global registry', () => {
     const globalCalls: string[] = []
     const scopedCalls: string[] = []

--- a/tests/pool.test.ts
+++ b/tests/pool.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach } from 'bun:test'
-import { acquireLayoutResult, releaseLayoutResult, clearLayoutPool } from '../src/render/pool.js'
+import { acquireLayoutResult, releaseLayoutResult, clearLayoutPool, getLayoutPoolSize } from '../src/render/pool.js'
 
 describe('LayoutResult Memory Pool', () => {
   beforeEach(() => {
@@ -83,6 +83,47 @@ describe('LayoutResult Memory Pool', () => {
 
     const acquired = acquireLayoutResult(20000)
     expect(acquired).not.toBe(huge)
+  })
+
+  test('pool evicts oldest entry when max pooled layouts is reached', () => {
+    const released: Array<ReturnType<typeof acquireLayoutResult>> = []
+
+    for (let i = 0; i < 33; i++) {
+      const result = acquireLayoutResult(i + 1)
+      releaseLayoutResult(result)
+      released.push(result)
+    }
+
+    expect(getLayoutPoolSize()).toBe(32)
+
+    const reacquired: Array<ReturnType<typeof acquireLayoutResult>> = []
+    for (let i = 0; i < 32; i++) {
+      reacquired.push(acquireLayoutResult(1))
+    }
+
+    expect(reacquired.includes(released[0]!)).toBe(false)
+  })
+
+  test('expired pool entries are pruned by age', () => {
+    const realNow = Date.now
+    const baseNow = 1_000_000
+    let now = baseNow
+    Date.now = () => now
+
+    try {
+      const stale = acquireLayoutResult(8)
+      releaseLayoutResult(stale)
+      expect(getLayoutPoolSize()).toBe(1)
+
+      now = baseNow + 30_001
+
+      const fresh = acquireLayoutResult(8)
+      expect(fresh).not.toBe(stale)
+      releaseLayoutResult(fresh)
+      expect(getLayoutPoolSize()).toBe(1)
+    } finally {
+      Date.now = realNow
+    }
   })
 
   test('clearLayoutPool empties the pool', () => {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -451,6 +451,26 @@ describe('router: app + async integration (RED)', () => {
     expect(out.children).toEqual([])
   })
 
+  test('async loader rejection surfaces errorFallback so the UI can react', async () => {
+    const Fallback = makeComponent('Load failed')
+    const AsyncPage = defineAsyncComponent<void>(
+      () => Promise.reject(new Error('boom')),
+      { errorFallback: Fallback }
+    )
+
+    // Pending: empty fragment before the loader settles.
+    expect(AsyncPage._fn(undefined as void).type).toBe('fragment')
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    const out = AsyncPage._fn(undefined as void)
+    expect(out.type).toBe('element')
+    if (out.type !== 'element') {
+      throw new Error('Expected errorFallback element after async loader rejection')
+    }
+    expect(out.children?.[0]).toMatchObject({ type: 'text', content: 'Load failed' })
+  })
+
   test('async route component renders through router+app after loader resolves', async () => {
     const Real = makeComponent('Real (router)')
     const loader = mock(() => Promise.resolve({ default: Real }))

--- a/tests/ssr-stream.test.ts
+++ b/tests/ssr-stream.test.ts
@@ -55,4 +55,32 @@ describe('renderToReadableStream()', () => {
     expect(result).toInclude('<title>Stream Test</title>')
     expect(result).toInclude('description" content="Testing stream SSR')
   })
+
+  test('accepts a plain-object component definition (e.g. defineAsyncComponent output)', async () => {
+    // A ComponentDefinition is an object with a callable `_fn`. Unlike
+    // defineComponent (which returns a callable function), object-form
+    // definitions must NOT be rejected by the runtime validation.
+    const objComponent = {
+      _id: Symbol('obj-component'),
+      _fn: () => h('section', null, 'Object Component'),
+    }
+
+    const stream = renderToReadableStream(objComponent)
+    const result = await readStream(stream)
+
+    expect(result).toStartWith('<!DOCTYPE html>')
+    expect(result).toInclude('Object Component')
+  })
+
+  test('throws on invalid component input', () => {
+    expect(() => renderToReadableStream(null as never)).toThrow(
+      'renderToReadableStream() requires a valid component definition'
+    )
+    expect(() => renderToReadableStream({} as never)).toThrow(
+      'renderToReadableStream() requires a valid component definition'
+    )
+    expect(() => renderToReadableStream('nope' as never)).toThrow(
+      'renderToReadableStream() requires a valid component definition'
+    )
+  })
 })


### PR DESCRIPTION
## Summary

Hardening batch 2 (C2 audit): request-scoped plugin context (`createAppContext`), runaway-recursion depth guard for `computed`, graceful hydration degradation in non-strict mode, age-based eviction of stale layout pool buffers, component-input validation in `renderToReadableStream`, and a global hook surfacing async component load errors in the router.

> **Chained PR 3 of 3 — base `chain/security-c2-batch1` (PR #77).** Final slice; merge last. Its integrated tree equals the original `feat/starter-demo-onboarding`.

### Dependency chain
```
main
 └─ PR #76  chain/onboarding-starter
     └─ PR #77  chain/security-c2-batch1
         └─ 📍 PR #C  chain/hardening-c2-batch2   (this PR)
```

### Review budget
- **Code (`src/`): 163 lines** · tests: 122 · OpenSpec docs: 0 · total ≈ 285. **Under the 400-line budget — no exception needed.**
- Focus: `src/features/plugin.ts`, `src/reactivity/signals.ts`, `src/render/commit.ts`, `src/render/pool*`, `src/render/ssr-stream.ts`, `src/router.ts`.

## Type of change
- [x] `fix` — bug fix (patch bump)

## Checklist
- [x] Tests added or updated for the changed behavior
- [x] `bun test` passes locally (full suite green on the integrated chain)
- [x] `bun run typecheck` passes locally
- [x] This PR links an issue (`Part of #30`)
- [ ] `docs/V1-0-0-EVIDENCE-LOG.md` — N/A (absent in branch)
- [x] Conventional Commits
- [x] Hot path invariant respected (pool eviction keeps reflow read-free)
- [x] No runtime dependencies added to `src/`

## Related issues
Part of #30

## Testing notes
Depends on #77 (which depends on #76). Merge order: #76 -> #77 -> this. After all three merge, `feat/starter-demo-onboarding` content is fully on `main`; PR #75 (stylesheet origin policy) should then be retargeted to `main`.

## Summary by Sourcery

Refuerza el comportamiento del runtime central en torno a plugins, reactividad, agrupación (pooling) de layouts, hidratación, SSR en streaming y manejo de errores en el enrutado asíncrono.

Nuevas funcionalidades:
- Introduce contextos de plugin con alcance por petición mediante `createAppContext()` para aislar los plugins por aplicación o por petición.
- Expone un hook global de error de carga de componentes asíncronos en el enrutador para que los hosts puedan observar fallos en los loaders.

Correcciones de errores:
- Añade una protección de profundidad de recursión para las señales computadas a fin de evitar bucles de re-evaluación incontrolados.
- Degrada la hidratación de forma gradual en modo no estricto capturando errores y mostrándolos como advertencias en lugar de provocar un bloqueo.
- Valida las definiciones de componentes pasadas a `renderToReadableStream()` y rechaza entradas inválidas de forma anticipada.
- Expulsa la entrada de layout más antigua del pool cuando el pool alcanza su tamaño máximo y depura entradas obsoletas por antigüedad para evitar retener buffers de larga duración.
- Garantiza que los errores de carga de componentes asíncronos ya no se silencien y puedan mostrarse en la UI.

Mejoras:
- Documenta y preserva el registro global de plugins, a la vez que aporta una guía más clara para un uso seguro en entornos multi-tenant.
- Refuerza el reporte del tamaño del pool de layouts depurando las entradas expiradas antes de devolver el tamaño del pool.

Tests:
- Amplía los tests de plugins para cubrir el nuevo comportamiento de `PluginScope` con alcance por petición y el manejo de errores.
- Añade tests del pool de layouts para verificar la expulsión basada en capacidad y la depuración basada en antigüedad.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden core runtime behavior around plugins, reactivity, layout pooling, hydration, streaming SSR, and async routing error handling.

New Features:
- Introduce request-scoped plugin contexts via createAppContext() to isolate plugins per app or request.
- Expose a global async component load error hook in the router so hosts can observe loader failures.

Bug Fixes:
- Add a recursion-depth guard for computed signals to prevent runaway re-evaluation loops.
- Degrade hydration gracefully in non-strict mode by catching errors and surfacing them as warnings instead of crashing.
- Validate component definitions passed to renderToReadableStream() and reject invalid inputs early.
- Evict the oldest layout pool entry when the pool reaches its maximum size and prune stale entries by age to avoid retaining long-lived buffers.
- Ensure async component loader errors are no longer silently swallowed and can be surfaced to the UI.

Enhancements:
- Document and preserve the global plugin registry while adding clearer guidance for multi-tenant-safe usage.
- Harden layout pool size reporting by pruning expired entries before returning the pool size.

Tests:
- Extend plugin tests to cover the new request-scoped PluginScope behavior and error handling.
- Add layout pool tests to verify capacity-based eviction and age-based pruning semantics.

</details>